### PR TITLE
Fix for zCut and volumeCut of 2D plot for multidimensional dataObjects

### DIFF
--- a/itom1DQwtPlot/dataObjectSeriesData.cpp
+++ b/itom1DQwtPlot/dataObjectSeriesData.cpp
@@ -151,7 +151,7 @@ RetVal DataObjectSeriesData::updateDataObject(const ito::DataObject* dataObj, QV
     int pxX1, pxX2, pxY1, pxY2;
     std::string description, unit;
 
-    if (dataObj == NULL)
+    if (dataObj == nullptr)
     {
         m_d.plane = 0;
         m_d.dir = dirZ;
@@ -164,436 +164,422 @@ RetVal DataObjectSeriesData::updateDataObject(const ito::DataObject* dataObj, QV
     {
         int dims = dataObj->getDims();
 
-        int prependedOneDims = 0;
-        for (int i = 0; i < dims-2; i++)
+        // this variable indicates how many of the first n-2 dimensions (all besides y and x),
+        // have a size > 1.
+        int numHigherDimsWithSizeBiggerThan1 = 0;
+        int idxOfFirstDimWithSizeBiggerThan1 = -1;
+
+        for (int i = 0; i < dims - 2; i++)
         {
-            if (dataObj->getSize(i) != 1)
+            if (dataObj->getSize(i) > 1)
             {
-                break;
+                numHigherDimsWithSizeBiggerThan1++;
+
+                if (idxOfFirstDimWithSizeBiggerThan1 == -1)
+                {
+                    idxOfFirstDimWithSizeBiggerThan1 = i;
+                }
             }
-            prependedOneDims++;
         }
 
         QVector<QPointF> tmpBounds;
 
         if (bounds.size() == 3)
         {
-            m_d.plane = bounds[0].x();
-            m_d.plane = dims > 2 ? std::min(m_d.plane, dataObj->getSize(dims-3)) : 0;
-            m_d.plane = std::max(m_d.plane, 0);
-            tmpBounds.resize(2);
-            tmpBounds[0] = bounds[1];
-            tmpBounds[1] = bounds[2];
+            m_d.plane = qBound(0, (int)bounds[0].x(), dataObj->getNumPlanes() - 1);
+            tmpBounds = bounds.mid(1, 2);
         }
         else
         {
             m_d.plane = 0;
             tmpBounds = bounds;
         }
+
         if (!dataObj->get_mdata() || !(cv::Mat*)(dataObj->get_mdata()[m_d.plane])->data)
+        {
             return ito::RetVal(ito::retError, 0, QObject::tr("cv:Mat in data object seems corrupted").toLatin1().data());
+        }
 
         switch( tmpBounds.size() )
         {
         case 2: //dirX, dirY or dirXY
+            m_d.valid = true;
+            pxX1 = qRound(dataObj->getPhysToPix(dims-1, tmpBounds[0].x(), _unused));
+            pxY1 = qRound(dataObj->getPhysToPix(dims-2, tmpBounds[0].y(), _unused));
+            pxX2 = qRound(dataObj->getPhysToPix(dims-1, tmpBounds[1].x(), _unused));
+            pxY2 = qRound(dataObj->getPhysToPix(dims-2, tmpBounds[1].y(), _unused));
 
-            if ( (dims-prependedOneDims) != 2 && (dims-prependedOneDims) != 3)
+            saturation( pxX1, 0, dataObj->getSize(dims-1)-1 );
+            saturation( pxX2, 0, dataObj->getSize(dims-1)-1 );
+            saturation( pxY1, 0, dataObj->getSize(dims-2)-1 );
+            saturation( pxY2, 0, dataObj->getSize(dims-2)-1 );
+
+            mat = (cv::Mat*)dataObj->get_mdata()[ dataObj->seekMat(m_d.plane) ]; //first plane in ROI
+
+            if ( pxX1 == pxX2 ) //pure line in y-direction
             {
-                m_d.valid = false;
-                retval += RetVal(retError, 0, "line plot requires a 2-dim dataObject or the first (n-2) dimensions must have a size of 1");
-            }
-            else
-            {
-                m_d.valid = true;
-                pxX1 = qRound(dataObj->getPhysToPix(dims-1, tmpBounds[0].x(), _unused));
-                pxY1 = qRound(dataObj->getPhysToPix(dims-2, tmpBounds[0].y(), _unused));
-                pxX2 = qRound(dataObj->getPhysToPix(dims-1, tmpBounds[1].x(), _unused));
-                pxY2 = qRound(dataObj->getPhysToPix(dims-2, tmpBounds[1].y(), _unused));
-
-                saturation( pxX1, 0, dataObj->getSize(dims-1)-1 );
-                saturation( pxX2, 0, dataObj->getSize(dims-1)-1 );
-                saturation( pxY1, 0, dataObj->getSize(dims-2)-1 );
-                saturation( pxY2, 0, dataObj->getSize(dims-2)-1 );
-
-                mat = (cv::Mat*)dataObj->get_mdata()[ dataObj->seekMat(m_d.plane) ]; //first plane in ROI
-
-                if ( pxX1 == pxX2 ) //pure line in y-direction
+                m_d.dir = dirY;
+                if (pxY2 >= pxY1)
                 {
-                    m_d.dir = dirY;
-                    if (pxY2 >= pxY1)
-                    {
-                        m_d.nrPoints = 1 + pxY2 - pxY1;
-                    }
-                    else
-                    {
-                        m_d.nrPoints = 1 + pxY1 - pxY2;
-                    }
-                    m_d.startPhys= dataObj->getPixToPhys(dims-2, pxY1, _unused); //tmpBounds[0].y() ;
-                    right = dataObj->getPixToPhys(dims-2, pxY2, _unused); //tmpBounds[1].y();
-                    m_d.stepSizePhys = m_d.nrPoints > 1 ? (right - m_d.startPhys) / (float)(m_d.nrPoints-1) : 0.0;
-
-                    m_d.startPx.setX(pxX1);
-                    m_d.startPx.setY(pxY1);
-                    m_d.stepSizePx.setWidth(0);
-                    m_d.stepSizePx.setHeight(1);
-
-                    m_d.matOffset = (int)mat->step[0] * pxY1 + (int)mat->step[1] * pxX1; //(&mat->at<char>(pxY1,pxX1) - &mat->at<char>(0,0));
-                    if (pxY2 >= pxY1)
-                    {
-                        m_d.matStepSize = (int)mat->step[0]; //step in y-direction (in bytes)
-                    }
-                    else
-                    {
-                        m_d.matStepSize = -(int)mat->step[0]; //step in y-direction (in bytes)
-                    }
-
-
-                    description = dataObj->getAxisDescription(dims-2,_unused);
-                    unit = dataObj->getAxisUnit(dims-2,_unused);
-                    if (description == "")
-                    {
-                        description = QObject::tr("y-axis").toLatin1().data();
-                    }
-                    if (unit == "")
-                    {
-                        m_dObjAxisDescription = fromStdLatin1String(description);
-                        m_dObjAxisUnit = "";
-                    }
-                    else
-                    {
-                        m_dObjAxisDescription = fromStdLatin1String(description);
-                        m_dObjAxisUnit = fromStdLatin1String(unit);
-                    }
-
-                    description = dataObj->getValueDescription();
-                    unit = dataObj->getValueUnit();
-                    if (unit == "")
-                    {
-                        m_dObjValueDescription = fromStdLatin1String(description);
-                        m_dObjValueUnit = "";
-                    }
-                    else
-                    {
-                        m_dObjValueDescription = fromStdLatin1String(description);
-                        m_dObjValueUnit = fromStdLatin1String(unit);
-                    }
+                    m_d.nrPoints = 1 + pxY2 - pxY1;
                 }
-                else if ( pxY1 == pxY2 ) //pure line in x-direction
+                else
                 {
-                    m_d.dir = dirX;
-                    if (pxX2 >= pxX1)
-                    {
-                        m_d.nrPoints = 1 + pxX2 - pxX1;
-                    }
-                    else {
-                        m_d.nrPoints = 1 + pxX1 - pxX2;
-                    }
+                    m_d.nrPoints = 1 + pxY1 - pxY2;
+                }
+                m_d.startPhys= dataObj->getPixToPhys(dims-2, pxY1, _unused);
+                right = dataObj->getPixToPhys(dims-2, pxY2, _unused);
+                m_d.stepSizePhys = m_d.nrPoints > 1 ? (right - m_d.startPhys) / (float)(m_d.nrPoints-1) : 0.0;
 
-                    m_d.startPhys= dataObj->getPixToPhys(dims-1, pxX1, _unused); //tmpBounds[0].y() ;
-                    right = dataObj->getPixToPhys(dims-1, pxX2, _unused); //tmpBounds[1].y();
-                    m_d.stepSizePhys = m_d.nrPoints > 1 ? (right - m_d.startPhys) / (float)(m_d.nrPoints-1) : 0.0;
+                m_d.startPx.setX(pxX1);
+                m_d.startPx.setY(pxY1);
+                m_d.stepSizePx.setWidth(0);
+                m_d.stepSizePx.setHeight(1);
 
-                    m_d.startPx.setX(pxX1);
-                    m_d.startPx.setY(pxY1);
-                    m_d.stepSizePx.setWidth(1);
-                    m_d.stepSizePx.setHeight(0);
+                m_d.matOffset = (int)mat->step[0] * pxY1 + (int)mat->step[1] * pxX1; //(&mat->at<char>(pxY1,pxX1) - &mat->at<char>(0,0));
+                if (pxY2 >= pxY1)
+                {
+                    m_d.matStepSize = (int)mat->step[0]; //step in y-direction (in bytes)
+                }
+                else
+                {
+                    m_d.matStepSize = -(int)mat->step[0]; //step in y-direction (in bytes)
+                }
 
-                    m_d.matOffset = (int)mat->step[0] * pxY1 + (int)mat->step[1] * pxX1; //(&mat->at<char>(pxY1,pxX1) - &mat->at<char>(0,0));
-                    if (pxX2 >= pxX1)
-                    {
-                        m_d.matStepSize = (int)mat->step[1]; //step in x-direction (in bytes)
-                        if (dataObj->getType() == ito::tUInt32) //since uint32 is not supported by openCV the step method returns the wrong result
-                        {
-                            m_d.matStepSize = 4;
-                        }
-                    }
-                    else
-                    {
-                        m_d.matStepSize = -(int)mat->step[1];
-                        if (dataObj->getType() == ito::tUInt32) //since uint32 is not supported by openCV the step method returns the wrong result
-                        {
-                            m_d.matStepSize = -4;
-                        }
-                    }
 
-                    /*}
-                    else
-                    {
-                        m_d.nrPoints = 1 + pxX1 - pxX2;
-                        m_d.startPhys = dataObj->getPixToPhys(dims-1, pxX2, _unused); //tmpBounds[1].y();
-                        right = dataObj->getPixToPhys(dims-1, pxX1, _unused); //tmpBounds[0].y();
-                        m_d.stepSizePhys = m_d.nrPoints > 1 ? (right - m_d.startPhys) / (float)(m_d.nrPoints-1) : 0.0;
+                description = dataObj->getAxisDescription(dims-2,_unused);
+                unit = dataObj->getAxisUnit(dims-2,_unused);
+                if (description == "")
+                {
+                    description = QObject::tr("y-axis").toLatin1().data();
+                }
+                if (unit == "")
+                {
+                    m_dObjAxisDescription = fromStdLatin1String(description);
+                    m_dObjAxisUnit = "";
+                }
+                else
+                {
+                    m_dObjAxisDescription = fromStdLatin1String(description);
+                    m_dObjAxisUnit = fromStdLatin1String(unit);
+                }
 
-                        m_d.startPx.setX(pxX1);
-                        m_d.startPx.setY(pxY2);
-                        m_d.stepSizePx.setWidth(1);
-                        m_d.stepSizePx.setHeight(0);
+                description = dataObj->getValueDescription();
+                unit = dataObj->getValueUnit();
+                if (unit == "")
+                {
+                    m_dObjValueDescription = fromStdLatin1String(description);
+                    m_dObjValueUnit = "";
+                }
+                else
+                {
+                    m_dObjValueDescription = fromStdLatin1String(description);
+                    m_dObjValueUnit = fromStdLatin1String(unit);
+                }
+            }
+            else if ( pxY1 == pxY2 ) //pure line in x-direction
+            {
+                m_d.dir = dirX;
+                if (pxX2 >= pxX1)
+                {
+                    m_d.nrPoints = 1 + pxX2 - pxX1;
+                }
+                else {
+                    m_d.nrPoints = 1 + pxX1 - pxX2;
+                }
 
-                        m_d.matOffset = (int)mat->step[0] * pxY1 + (int)mat->step[1] * pxX2; //(&mat->at<char>(pxY1,pxX2) - &mat->at<char>(0,0));
-                        m_d.matStepSize= (int)mat->step[1] ; //step in x-direction (in bytes)
-                    }*/
+                m_d.startPhys= dataObj->getPixToPhys(dims-1, pxX1, _unused); //tmpBounds[0].y() ;
+                right = dataObj->getPixToPhys(dims-1, pxX2, _unused); //tmpBounds[1].y();
+                m_d.stepSizePhys = m_d.nrPoints > 1 ? (right - m_d.startPhys) / (float)(m_d.nrPoints-1) : 0.0;
 
-                    description = dataObj->getAxisDescription(dims-1,_unused);
-                    unit = dataObj->getAxisUnit(dims-1,_unused);
-                    if (description == "")
-                    {
-                        description = QObject::tr("x-axis").toLatin1().data();
-                    }
-                    if (unit == "")
-                    {
-                        m_dObjAxisDescription = fromStdLatin1String(description);
-                        m_dObjAxisUnit = "";
-                    }
-                    else
-                    {
-                        m_dObjAxisDescription = fromStdLatin1String(description);
-                        m_dObjAxisUnit = fromStdLatin1String(unit);
-                    }
+                m_d.startPx.setX(pxX1);
+                m_d.startPx.setY(pxY1);
+                m_d.stepSizePx.setWidth(1);
+                m_d.stepSizePx.setHeight(0);
 
-                    description = dataObj->getValueDescription();
-                    unit = dataObj->getValueUnit();
-                    if (unit == "")
+                m_d.matOffset = (int)mat->step[0] * pxY1 + (int)mat->step[1] * pxX1; //(&mat->at<char>(pxY1,pxX1) - &mat->at<char>(0,0));
+                if (pxX2 >= pxX1)
+                {
+                    m_d.matStepSize = (int)mat->step[1]; //step in x-direction (in bytes)
+                    if (dataObj->getType() == ito::tUInt32) //since uint32 is not supported by openCV the step method returns the wrong result
                     {
-                        m_dObjValueDescription = fromStdLatin1String(description);
-                        m_dObjValueUnit = "";
-                    }
-                    else
-                    {
-                        m_dObjValueDescription = fromStdLatin1String(description);
-                        m_dObjValueUnit = fromStdLatin1String(unit);
+                        m_d.matStepSize = 4;
                     }
                 }
                 else
                 {
-                    m_d.dir = dirXY;
-
-                    if (m_fast)
+                    m_d.matStepSize = -(int)mat->step[1];
+                    if (dataObj->getType() == ito::tUInt32) //since uint32 is not supported by openCV the step method returns the wrong result
                     {
-                        // simple line points calculation using Bresenham
-                        // http://de.wikipedia.org/wiki/Bresenham-Algorithmus#C-Implementierung
+                        m_d.matStepSize = -4;
+                    }
+                }
 
-                        int dx = abs( pxX2 - pxX1 );
-                        int incx = pxX1 <= pxX2 ? 1 : -1;
-                        int dy = abs( pxY2 - pxY1 );
-                        int incy = pxY1 <= pxY2 ? 1 : -1;
+                description = dataObj->getAxisDescription(dims-1,_unused);
+                unit = dataObj->getAxisUnit(dims-1,_unused);
+                if (description == "")
+                {
+                    description = QObject::tr("x-axis").toLatin1().data();
+                }
+                if (unit == "")
+                {
+                    m_dObjAxisDescription = fromStdLatin1String(description);
+                    m_dObjAxisUnit = "";
+                }
+                else
+                {
+                    m_dObjAxisDescription = fromStdLatin1String(description);
+                    m_dObjAxisUnit = fromStdLatin1String(unit);
+                }
 
-                        m_d.nrPoints = 1 + std::max(dx,dy);
+                description = dataObj->getValueDescription();
+                unit = dataObj->getValueUnit();
+                if (unit == "")
+                {
+                    m_dObjValueDescription = fromStdLatin1String(description);
+                    m_dObjValueUnit = "";
+                }
+                else
+                {
+                    m_dObjValueDescription = fromStdLatin1String(description);
+                    m_dObjValueUnit = fromStdLatin1String(unit);
+                }
+            }
+            else
+            {
+                m_d.dir = dirXY;
 
-                        m_d.startPhys = 0.0;  //there is no physical starting point for diagonal lines.
+                if (m_fast)
+                {
+                    // simple line points calculation using Bresenham
+                    // http://de.wikipedia.org/wiki/Bresenham-Algorithmus#C-Implementierung
 
-                        if (m_d.nrPoints > 0)
-                        {
-                            double dxPhys = dataObj->getPixToPhys(dims-1, pxX2, _unused) - dataObj->getPixToPhys(dims-1, pxX1, _unused);
-                            double dyPhys = dataObj->getPixToPhys(dims-2, pxY2, _unused) - dataObj->getPixToPhys(dims-2, pxY1, _unused);
-                            m_d.stepSizePhys = sqrt((dxPhys * dxPhys) + (dyPhys * dyPhys)) / (m_d.nrPoints - 1);
-                        }
-                        else
-                        {
-                            m_d.stepSizePhys = 0.0;
-                        }
+                    int dx = abs( pxX2 - pxX1 );
+                    int incx = pxX1 <= pxX2 ? 1 : -1;
+                    int dy = abs( pxY2 - pxY1 );
+                    int incy = pxY1 <= pxY2 ? 1 : -1;
 
-                        m_d.startPx.setX(pxX1);
-                        m_d.startPx.setY(pxY1);
-                        m_d.stepSizePx.setWidth(incx);
-                        m_d.stepSizePx.setHeight(incy);
+                    m_d.nrPoints = 1 + std::max(dx,dy);
 
-                        m_d.matOffset = (int)mat->step[0] * pxY1 + (int)mat->step[1] * pxX1; //(&mat->at<char>(pxY1,pxX1) - &mat->at<char>(0,0));
-                        m_d.matStepSize= 0 ;
+                    m_d.startPhys = 0.0;  //there is no physical starting point for diagonal lines.
 
-                        int pdx, pdy, ddx, ddy, es, el;
-                        if (dx>dy)
-                        {
-                            pdx = incx;
-                            pdy = 0;
-                            ddx = incx;
-                            ddy = incy;
-                            es = dy;
-                            el = dx;
-                        }
-                        else
-                        {
-                            pdx = 0;
-                            pdy = incy;
-                            ddx = incx;
-                            ddy = incy;
-                            es = dx;
-                            el = dy;
-                        }
-
-                        int err = el / 2; //0; /* error value e_xy */
-                        int x = 0; //pxX1;
-                        int y = 0; //pxY1;
-
-                        m_d.matSteps.resize((int)m_d.nrPoints);
-
-                        for (unsigned int n = 0; n < (unsigned int)m_d.nrPoints; n++)
-                        {  /* loop */
-                            //setPixel(x,y)
-                            m_d.matSteps[n] = (int)mat->step[0] * y + (int)mat->step[1] * x;
-
-                            err -= es;
-                            if (err < 0)
-                            {
-                                err += el;
-                                x += ddx;
-                                y += ddy;
-                            }
-                            else
-                            {
-                                x += pdx;
-                                y += pdy;
-                            }
-                        }
+                    if (m_d.nrPoints > 0)
+                    {
+                        double dxPhys = dataObj->getPixToPhys(dims-1, pxX2, _unused) - dataObj->getPixToPhys(dims-1, pxX1, _unused);
+                        double dyPhys = dataObj->getPixToPhys(dims-2, pxY2, _unused) - dataObj->getPixToPhys(dims-2, pxY1, _unused);
+                        m_d.stepSizePhys = sqrt((dxPhys * dxPhys) + (dyPhys * dyPhys)) / (m_d.nrPoints - 1);
                     }
                     else
                     {
-                        //// "full" calculation of line points using interpolation values for always four neighbouring point
-                        //double dx = (tmpBounds[1].x() - tmpBounds[0].x());
-                        //double dy = (tmpBounds[1].y() - tmpBounds[0].y());
-                        //double sizex = dataObj->getSize(dims-1);
-                        //double sizey = dataObj->getSize(dims-2);
-
-                        //double length = sqrt((double)(dx * dx + dy * dy));
-                        //double stepx, stepy;
-                        //if (dx == 0)
-                        //{
-                        //    stepx = 0;
-                        //}
-                        //else
-                        //{
-                        //    xdirect = true;
-                        //    stepx = dx / length;
-                        //}
-
-                        //if (dy == 0)
-                        //{
-                        //    stepy = 0;
-                        //}
-                        //else
-                        //{
-                        //    ydirect = true;
-                        //    stepy = dy / length;
-                        //}
-                        //m_size = floor(length) + 1;
-
-                        //if (xdirect && ydirect)
-                        //{
-                        //    m_startPos = 0.0;
-                        //    m_physLength = sqrt((double)(xscale* xscale* dx * dx + yscale * yscale * dy * dy));
-                        //}
-                        //else if (ydirect)
-                        //{
-                        //    m_startPos = tmpBounds[0].y();
-                        //    m_physLength = yscale* dy ;
-                        //}
-                        //else
-                        //{
-                        //    m_startPos = tmpBounds[0].x();
-                        //    m_physLength = xscale* dx ;
-                        //}
-
-                        //m_Scaling = m_physLength / length;
-
-                        //double xsub, ysub, xpos, ypos;
-
-                        //m_plotPts.resize(m_size);
-                        //for (unsigned int n = 0; n < m_size; n++)
-                        //{
-                        //    xpos = pts[0].x() + n * stepx;
-                        //    ypos = pts[0].y() + n * stepy;
-
-                        //    if (xpos >= sizex - 1)
-                        //    {
-                        //        if (xpos >= sizex)
-                        //        {
-                        //            xpos = sizex - 1;
-                        //        }
-                        //        m_plotPts[n].rangeX[1] =  static_cast<int32>(sizex - 1);
-                        //    }
-                        //    else
-                        //    {
-                        //        m_plotPts[n].rangeX[1] =  static_cast<int32>(floor(xpos) + 1);
-                        //    }
-
-                        //    if (ypos >= sizey - 1)
-                        //    {
-                        //        if (ypos >= sizey)
-                        //        {
-                        //            ypos = sizey - 1;
-                        //        }
-                        //        m_plotPts[n].rangeY[1] =  static_cast<int32>(sizey - 1);
-                        //    }
-                        //    else
-                        //    {
-                        //        m_plotPts[n].rangeY[1] =  static_cast<int32>(floor(ypos) + 1);
-                        //    }
-
-                        //    m_plotPts[n].rangeX[0] = floor(xpos);
-                        //    m_plotPts[n].rangeY[0] = floor(ypos);
-                        //    xsub = xpos - m_plotPts[n].rangeX[0];
-                        //    ysub = ypos - m_plotPts[n].rangeY[0];
-                        //    m_plotPts[n].weights[0] = (1 - xsub) * (1 - ysub);
-                        //    m_plotPts[n].weights[1] = (1 - xsub) * ysub;
-                        //    m_plotPts[n].weights[2] = xsub * ysub;
-                        //    m_plotPts[n].weights[3] = xsub * (1 - ysub);
-                        //}
+                        m_d.stepSizePhys = 0.0;
                     }
 
-                    description = dataObj->getAxisDescription(dims-2,_unused);
-                    unit = dataObj->getAxisUnit(dims-2,_unused);
-                    if (unit == "") unit = "px";
+                    m_d.startPx.setX(pxX1);
+                    m_d.startPx.setY(pxY1);
+                    m_d.stepSizePx.setWidth(incx);
+                    m_d.stepSizePx.setHeight(incy);
 
-                    std::string descr2 = dataObj->getAxisDescription(dims-1, _unused);
-                    std::string unit2 = dataObj->getAxisUnit(dims-1, _unused);
-                    if (unit2 == "") unit2 = "px";
+                    m_d.matOffset = (int)mat->step[0] * pxY1 + (int)mat->step[1] * pxX1; //(&mat->at<char>(pxY1,pxX1) - &mat->at<char>(0,0));
+                    m_d.matStepSize= 0 ;
 
-                    if (description == "" && descr2 == "")
+                    int pdx, pdy, ddx, ddy, es, el;
+                    if (dx>dy)
                     {
-                        if (unit == "" && unit2 == "")
-                        {
-                            m_dObjAxisDescription = QObject::tr("x/y-axis");
-                            m_dObjAxisUnit = "";
-                        }
-                        else
-                        {
-                            m_dObjAxisDescription = QObject::tr("x/y-axis");
-                            m_dObjAxisUnit = QString("%1/%2").arg( fromStdLatin1String(unit), fromStdLatin1String(unit2) );
-                        }
+                        pdx = incx;
+                        pdy = 0;
+                        ddx = incx;
+                        ddy = incy;
+                        es = dy;
+                        el = dx;
                     }
                     else
                     {
-                        if (unit == "" && unit2 == "")
+                        pdx = 0;
+                        pdy = incy;
+                        ddx = incx;
+                        ddy = incy;
+                        es = dx;
+                        el = dy;
+                    }
+
+                    int err = el / 2; //0; /* error value e_xy */
+                    int x = 0; //pxX1;
+                    int y = 0; //pxY1;
+
+                    m_d.matSteps.resize((int)m_d.nrPoints);
+
+                    for (unsigned int n = 0; n < (unsigned int)m_d.nrPoints; n++)
+                    {  /* loop */
+                        //setPixel(x,y)
+                        m_d.matSteps[n] = (int)mat->step[0] * y + (int)mat->step[1] * x;
+
+                        err -= es;
+                        if (err < 0)
                         {
-                            m_dObjAxisDescription = QString("%1/%2").arg( fromStdLatin1String(description), fromStdLatin1String(descr2) );
-                            m_dObjAxisUnit = "";
+                            err += el;
+                            x += ddx;
+                            y += ddy;
                         }
                         else
                         {
-                            m_dObjAxisDescription = QString("%1/%2").arg( fromStdLatin1String(description), fromStdLatin1String(descr2) );
-                            m_dObjAxisUnit = QString("%1/%2").arg( fromStdLatin1String(unit), fromStdLatin1String(unit2) );
+                            x += pdx;
+                            y += pdy;
                         }
                     }
+                }
+                else
+                {
+                    //// "full" calculation of line points using interpolation values for always four neighbouring point
+                    //double dx = (tmpBounds[1].x() - tmpBounds[0].x());
+                    //double dy = (tmpBounds[1].y() - tmpBounds[0].y());
+                    //double sizex = dataObj->getSize(dims-1);
+                    //double sizey = dataObj->getSize(dims-2);
 
-                    description = dataObj->getValueDescription();
-                    unit = dataObj->getValueUnit();
-                    if (unit == "")
+                    //double length = sqrt((double)(dx * dx + dy * dy));
+                    //double stepx, stepy;
+                    //if (dx == 0)
+                    //{
+                    //    stepx = 0;
+                    //}
+                    //else
+                    //{
+                    //    xdirect = true;
+                    //    stepx = dx / length;
+                    //}
+
+                    //if (dy == 0)
+                    //{
+                    //    stepy = 0;
+                    //}
+                    //else
+                    //{
+                    //    ydirect = true;
+                    //    stepy = dy / length;
+                    //}
+                    //m_size = floor(length) + 1;
+
+                    //if (xdirect && ydirect)
+                    //{
+                    //    m_startPos = 0.0;
+                    //    m_physLength = sqrt((double)(xscale* xscale* dx * dx + yscale * yscale * dy * dy));
+                    //}
+                    //else if (ydirect)
+                    //{
+                    //    m_startPos = tmpBounds[0].y();
+                    //    m_physLength = yscale* dy ;
+                    //}
+                    //else
+                    //{
+                    //    m_startPos = tmpBounds[0].x();
+                    //    m_physLength = xscale* dx ;
+                    //}
+
+                    //m_Scaling = m_physLength / length;
+
+                    //double xsub, ysub, xpos, ypos;
+
+                    //m_plotPts.resize(m_size);
+                    //for (unsigned int n = 0; n < m_size; n++)
+                    //{
+                    //    xpos = pts[0].x() + n * stepx;
+                    //    ypos = pts[0].y() + n * stepy;
+
+                    //    if (xpos >= sizex - 1)
+                    //    {
+                    //        if (xpos >= sizex)
+                    //        {
+                    //            xpos = sizex - 1;
+                    //        }
+                    //        m_plotPts[n].rangeX[1] =  static_cast<int32>(sizex - 1);
+                    //    }
+                    //    else
+                    //    {
+                    //        m_plotPts[n].rangeX[1] =  static_cast<int32>(floor(xpos) + 1);
+                    //    }
+
+                    //    if (ypos >= sizey - 1)
+                    //    {
+                    //        if (ypos >= sizey)
+                    //        {
+                    //            ypos = sizey - 1;
+                    //        }
+                    //        m_plotPts[n].rangeY[1] =  static_cast<int32>(sizey - 1);
+                    //    }
+                    //    else
+                    //    {
+                    //        m_plotPts[n].rangeY[1] =  static_cast<int32>(floor(ypos) + 1);
+                    //    }
+
+                    //    m_plotPts[n].rangeX[0] = floor(xpos);
+                    //    m_plotPts[n].rangeY[0] = floor(ypos);
+                    //    xsub = xpos - m_plotPts[n].rangeX[0];
+                    //    ysub = ypos - m_plotPts[n].rangeY[0];
+                    //    m_plotPts[n].weights[0] = (1 - xsub) * (1 - ysub);
+                    //    m_plotPts[n].weights[1] = (1 - xsub) * ysub;
+                    //    m_plotPts[n].weights[2] = xsub * ysub;
+                    //    m_plotPts[n].weights[3] = xsub * (1 - ysub);
+                    //}
+                }
+
+                description = dataObj->getAxisDescription(dims-2,_unused);
+                unit = dataObj->getAxisUnit(dims-2,_unused);
+                if (unit == "") unit = "px";
+
+                std::string descr2 = dataObj->getAxisDescription(dims-1, _unused);
+                std::string unit2 = dataObj->getAxisUnit(dims-1, _unused);
+                if (unit2 == "") unit2 = "px";
+
+                if (description == "" && descr2 == "")
+                {
+                    if (unit == "" && unit2 == "")
                     {
-                        m_dObjValueDescription = fromStdLatin1String(description);
-                        m_dObjValueUnit = "";
+                        m_dObjAxisDescription = QObject::tr("x/y-axis");
+                        m_dObjAxisUnit = "";
                     }
                     else
                     {
-                        m_dObjValueDescription = fromStdLatin1String(description);
-                        m_dObjValueUnit = fromStdLatin1String(unit);
+                        m_dObjAxisDescription = QObject::tr("x/y-axis");
+                        m_dObjAxisUnit = QString("%1/%2").arg( fromStdLatin1String(unit), fromStdLatin1String(unit2) );
                     }
+                }
+                else
+                {
+                    if (unit == "" && unit2 == "")
+                    {
+                        m_dObjAxisDescription = QString("%1/%2").arg( fromStdLatin1String(description), fromStdLatin1String(descr2) );
+                        m_dObjAxisUnit = "";
+                    }
+                    else
+                    {
+                        m_dObjAxisDescription = QString("%1/%2").arg( fromStdLatin1String(description), fromStdLatin1String(descr2) );
+                        m_dObjAxisUnit = QString("%1/%2").arg( fromStdLatin1String(unit), fromStdLatin1String(unit2) );
+                    }
+                }
+
+                description = dataObj->getValueDescription();
+                unit = dataObj->getValueUnit();
+                if (unit == "")
+                {
+                    m_dObjValueDescription = fromStdLatin1String(description);
+                    m_dObjValueUnit = "";
+                }
+                else
+                {
+                    m_dObjValueDescription = fromStdLatin1String(description);
+                    m_dObjValueUnit = fromStdLatin1String(unit);
                 }
             }
 
             break;
-        case 1:
-            if ((dims - prependedOneDims) != 3)
+        case 1: // dirZ
+            if (numHigherDimsWithSizeBiggerThan1 != 1)
             {
-                retval += RetVal(retError, 0, "line plot in z-direction requires a 3-dim dataObject");
+                retval += RetVal(
+                    retError,
+                    0,
+                    "line plot in z-direction requires a dataObject with n >= 3 dimensions, where only one of the first n-2 dimensions has a size != 1."
+                );
+
                 return retval;
             }
             else
@@ -606,11 +592,12 @@ RetVal DataObjectSeriesData::updateDataObject(const ito::DataObject* dataObj, QV
                 saturation( pxX2, 0, dataObj->getSize(dims - 1) - 1 );
 
                 m_d.dir = dirZ;
-                m_d.nrPoints = dataObj->getSize(dims - 3);
-                m_d.startPhys = dataObj->getPixToPhys(dims - 3,0,_unused);
+                m_d.nrPoints = dataObj->getSize(idxOfFirstDimWithSizeBiggerThan1);
+                m_d.startPhys = dataObj->getPixToPhys(idxOfFirstDimWithSizeBiggerThan1, 0, _unused);
+
                 if (m_d.nrPoints > 1)
                 {
-                    right = dataObj->getPixToPhys(dims - 3, m_d.nrPoints - 1, _unused);
+                    right = dataObj->getPixToPhys(idxOfFirstDimWithSizeBiggerThan1, m_d.nrPoints - 1, _unused);
                     m_d.stepSizePhys = (right - m_d.startPhys) / (float)(m_d.nrPoints - 1);
                 }
                 else
@@ -627,12 +614,21 @@ RetVal DataObjectSeriesData::updateDataObject(const ito::DataObject* dataObj, QV
                 m_d.matOffset = (int)mat->step[0] * pxY1 + (int)mat->step[1] * pxX1; //(&mat->at<char>(pxY1,pxX1) - &mat->at<char>(0,0));
                 m_d.matStepSize= 0 ; //step in x-direction (in bytes)
 
-                description = dataObj->getAxisDescription(dims - 3, _unused);
-                unit = dataObj->getAxisUnit(dims - 3, _unused);
+                description = dataObj->getAxisDescription(idxOfFirstDimWithSizeBiggerThan1, _unused);
+                unit = dataObj->getAxisUnit(idxOfFirstDimWithSizeBiggerThan1, _unused);
+
                 if (description == "")
                 {
-                    description = QObject::tr("z-axis").toLatin1().data();
+                    if (idxOfFirstDimWithSizeBiggerThan1 == dims - 3)
+                    {
+                        description = QObject::tr("z-axis").toLatin1().data();
+                    }
+                    else
+                    {
+                        description = QObject::tr("axis %1").arg(idxOfFirstDimWithSizeBiggerThan1).toLatin1().data();
+                    }
                 }
+
                 if (unit == "")
                 {
                     m_dObjAxisDescription = fromStdLatin1String(description);
@@ -646,6 +642,7 @@ RetVal DataObjectSeriesData::updateDataObject(const ito::DataObject* dataObj, QV
 
                 description = dataObj->getValueDescription();
                 unit = dataObj->getValueUnit();
+
                 if (unit == "")
                 {
                     m_dObjValueDescription = fromStdLatin1String(description);
@@ -687,202 +684,6 @@ RetVal DataObjectSeriesData::updateDataObject(const ito::DataObject* dataObj, QV
     calcHash();
 
     return retval;
-
-    //if ((bounds.size() == 1) && (dataObjectDims > 2))
-    //{
-    //    m_zDirect = true;
-    //}
-    //else
-    //{
-    //    m_zDirect = false;
-    //}
-
-    //pts[0].setX(static_cast<float>(dataObj->getPhysToPix(dataObjectDims-1,bounds[0].x(),testValid)));
-    //pts[0].setY(static_cast<float>(dataObj->getPhysToPix(dataObjectDims-2,bounds[0].y(),testValid)));
-
-    //if (m_zDirect)
-    //{
-    //    ito::DataObject tempObj = *dataObj;
-    //    dataObjectDims = tempObj.getDims();
-    //    int* limits = new int[2*dataObjectDims];
-    //    memset(limits, 0, sizeof(int) * 2*dataObjectDims);
-
-    //    tempObj.locateROI(limits);
-
-    //    limits[2*(dataObjectDims - 3)] *= -1;
-    //    limits[2*(dataObjectDims - 3) + 1] *= -1;
-
-    //    tempObj.adjustROI(dataObjectDims,limits);
-    //    delete limits;
-
-    //    m_size = tempObj.getSize(dataObjectDims - 3);
-    //    m_startPos = tempObj.getPixToPhys(dataObjectDims - 3, 0.0, testValid);
-    //    m_physLength = tempObj.getPixToPhys(dataObjectDims - 3, m_size, testValid) - m_startPos;
-    //    m_Scaling = m_physLength / m_size;
-
-    //    m_plotPts.resize(m_size);
-    //    for (unsigned int n = 0; n < m_size; n++)
-    //    {
-    //        m_plotPts[n].rangeX[0] = pts[0].x();
-    //        m_plotPts[n].rangeY[0] = pts[0].y();
-    //        m_plotPts[n].weights[0] = 1;
-    //    }
-    //}
-    //else //not z-direct
-    //{
-
-    //    bool xdirect = false;
-    //    bool ydirect = false;
-    //    if (bounds.size() == 1)
-    //    {
-    //        pts[1] = pts[0];
-    //    }
-    //    else
-    //    {
-    //        pts[1].setX(static_cast<float>(dataObj->getPhysToPix(dataObjectDims-1,bounds[1].x(),testValid)));
-    //        pts[1].setY(static_cast<float>(dataObj->getPhysToPix(dataObjectDims-2,bounds[1].y(),testValid)));
-    //    }
-
-    //    double xscale = dataObj->getAxisScale(dataObjectDims - 1);
-
-    //    double yscale = 1;
-    //    if (dataObjectDims > 1)
-    //    {
-    //        yscale = dataObj->getAxisScale(dataObjectDims - 2);
-    //    }
-
-        //if (m_fast)
-        //{
-        //    // simple line points calculation using Bresenham
-        //    int dx = abs(pts[1].x() - pts[0].x());
-        //    int sx = pts[0].x() < pts[1].x() ? 1 : -1;
-        //    int dy = -abs(pts[1].y() - pts[0].y());
-        //    int sy = pts[0].y() < pts[1].y() ? 1 : -1;
-        //    int err = dx + dy, e2 = 0; /* error value e_xy */
-        //    int x = pts[0].x();
-        //    int y = pts[0].y();
-
-        //    if (dx > -dy)
-        //        m_size = dx;
-        //    else
-        //        m_size = -dy;
-
-        //    m_plotPts.resize(m_size);
-
-        //    for (unsigned int n = 0; n < m_size; n++)
-        //    {  /* loop */
-        //        m_plotPts[n].rangeX[0] = x;
-        //        m_plotPts[n].rangeY[0] = y;
-        //        m_plotPts[n].weights[0] = 1;
-
-        //        e2 = 2 * err;
-        //        if (e2 > dy)
-        //        {
-        //            err += dy;
-        //            x += sx;
-        //        } /* e_xy+e_x > 0 */
-        //        if (e2 < dx)
-        //        {
-        //            err += dx;
-        //            y += sy;
-        //        } /* e_xy+e_y < 0 */
-        //    }
-        //}
-        //else
-        //{
-        //    // "full" calculation of line points using interpolation values for always four neighbouring point
-        //    double dx = (pts[1].x() - pts[0].x());
-        //    double dy = (pts[1].y() - pts[0].y());
-        //    double sizex = dataObj->getSize(dataObjectDims-1);
-        //    double sizey = dataObj->getSize(dataObjectDims-2);
-
-        //    double length = sqrt((double)(dx * dx + dy * dy));
-        //    double stepx, stepy;
-        //    if (dx == 0)
-        //    {
-        //        stepx = 0;
-        //    }
-        //    else
-        //    {
-        //        xdirect = true;
-        //        stepx = dx / length;
-        //    }
-
-        //    if (dy == 0)
-        //    {
-        //        stepy = 0;
-        //    }
-        //    else
-        //    {
-        //        ydirect = true;
-        //        stepy = dy / length;
-        //    }
-        //    m_size = floor(length) + 1;
-
-        //    if (xdirect && ydirect)
-        //    {
-        //        m_startPos = 0.0;
-        //        m_physLength = sqrt((double)(xscale* xscale* dx * dx + yscale * yscale * dy * dy));
-        //    }
-        //    else if (ydirect)
-        //    {
-        //        m_startPos = bounds[0].y();
-        //        m_physLength = yscale* dy ;
-        //    }
-        //    else
-        //    {
-        //        m_startPos = bounds[0].x();
-        //        m_physLength = xscale* dx ;
-        //    }
-
-        //    m_Scaling = m_physLength / length;
-
-        //    double xsub, ysub, xpos, ypos;
-
-        //    m_plotPts.resize(m_size);
-        //    for (unsigned int n = 0; n < m_size; n++)
-        //    {
-        //        xpos = pts[0].x() + n * stepx;
-        //        ypos = pts[0].y() + n * stepy;
-
-        //        if (xpos >= sizex - 1)
-        //        {
-        //            if (xpos >= sizex)
-        //            {
-        //                xpos = sizex - 1;
-        //            }
-        //            m_plotPts[n].rangeX[1] =  static_cast<int32>(sizex - 1);
-        //        }
-        //        else
-        //        {
-        //            m_plotPts[n].rangeX[1] =  static_cast<int32>(floor(xpos) + 1);
-        //        }
-
-        //        if (ypos >= sizey - 1)
-        //        {
-        //            if (ypos >= sizey)
-        //            {
-        //                ypos = sizey - 1;
-        //            }
-        //            m_plotPts[n].rangeY[1] =  static_cast<int32>(sizey - 1);
-        //        }
-        //        else
-        //        {
-        //            m_plotPts[n].rangeY[1] =  static_cast<int32>(floor(ypos) + 1);
-        //        }
-
-        //        m_plotPts[n].rangeX[0] = floor(xpos);
-        //        m_plotPts[n].rangeY[0] = floor(ypos);
-        //        xsub = xpos - m_plotPts[n].rangeX[0];
-        //        ysub = ypos - m_plotPts[n].rangeY[0];
-        //        m_plotPts[n].weights[0] = (1 - xsub) * (1 - ysub);
-        //        m_plotPts[n].weights[1] = (1 - xsub) * ysub;
-        //        m_plotPts[n].weights[2] = xsub * ysub;
-        //        m_plotPts[n].weights[3] = xsub * (1 - ysub);
-        //    }
-        //}
-    //}
-    //m_pDataObj = dataObj;
 }
 
 //----------------------------------------------------------------------------------------------------------------------------------
@@ -1043,541 +844,6 @@ QPointF DataObjectSeriesData::sample(size_t n) const
     }
 
     return QPointF();
-
-    //if (m_pDataObj)
-    //{
-    //    if (m_pDataObj->getDims() == 2)
-    //    {
-    //        double fPos;
-
-    //        if (m_Scaling > 0) fPos = n * m_Scaling + m_startPos;
-    //        else fPos = n * abs(m_Scaling) + m_startPos  + m_physLength;
-
-    //        if (m_fast)
-    //        {
-    //            switch(m_pDataObj->getType())
-    //            {
-    //                case ito::tInt8:
-    //                    return QPointF(fPos, m_pDataObj->at<int8>(m_plotPts[n].rangeY[0], m_plotPts[n].rangeX[0]));
-    //                break;
-    //                case ito::tUInt8:
-    //                    return QPointF(fPos, m_pDataObj->at<uint8>(m_plotPts[n].rangeY[0], m_plotPts[n].rangeX[0]));
-    //                break;
-    //                case ito::tInt16:
-    //                    return QPointF(fPos, m_pDataObj->at<int16>(m_plotPts[n].rangeY[0], m_plotPts[n].rangeX[0]));
-    //                break;
-    //                case ito::tUInt16:
-    //                    return QPointF(fPos, m_pDataObj->at<uint16>(m_plotPts[n].rangeY[0], m_plotPts[n].rangeX[0]));
-    //                break;
-    //                case ito::tInt32:
-    //                    return QPointF(fPos, m_pDataObj->at<int32>(m_plotPts[n].rangeY[0], m_plotPts[n].rangeX[0]));
-    //                break;
-    //                case ito::tUInt32:
-    //                    return QPointF(fPos, m_pDataObj->at<uint32>(m_plotPts[n].rangeY[0], m_plotPts[n].rangeX[0]));
-    //                break;
-    //                case ito::tFloat32:
-    //                    return QPointF(fPos, m_pDataObj->at<float>(m_plotPts[n].rangeY[0], m_plotPts[n].rangeX[0]));
-    //                break;
-    //                case ito::tFloat64:
-    //                    return QPointF(fPos, m_pDataObj->at<double>(m_plotPts[n].rangeY[0], m_plotPts[n].rangeX[0]));
-    //                break;
-    //                case ito::tComplex64:
-                //    {
-                //        switch (m_cmplxState)
-                //        {
-                //            default:
-    //                        case cmplxAbs:
-                //                return QPointF(fPos, abs(m_pDataObj->at<ito::complex64>(m_plotPts[n].rangeY[0], m_plotPts[n].rangeX[0])));
-                //            break;
-                //            case cmplxReal:
-                //                return QPointF(fPos, (m_pDataObj->at<ito::complex64>(m_plotPts[n].rangeY[0], m_plotPts[n].rangeX[0]).real()));
-                //            break;
-                //            case cmplxImag:
-                //                return QPointF(fPos, (m_pDataObj->at<ito::complex64>(m_plotPts[n].rangeY[0], m_plotPts[n].rangeX[0]).imag()));
-                //            break;
-                //            case cmplxArg:
-                //                return QPointF(fPos, arg(m_pDataObj->at<ito::complex64>(m_plotPts[n].rangeY[0], m_plotPts[n].rangeX[0])));
-                //            break;
-                //        }
-                //    }
-    //                break;
-    //                case ito::tComplex128:
-                //    {
-                //        switch (m_cmplxState)
-                //        {
-                //            default:
-                //            case cmplxAbs:
-                //                return QPointF(fPos, abs(m_pDataObj->at<ito::complex128>(m_plotPts[n].rangeY[0], m_plotPts[n].rangeX[0])));
-                //            break;
-                //            case cmplxReal:
-                //                return QPointF(fPos, (m_pDataObj->at<ito::complex128>(m_plotPts[n].rangeY[0], m_plotPts[n].rangeX[0]).real()));
-                //            break;
-                //            case cmplxImag:
-                //                return QPointF(fPos, (m_pDataObj->at<ito::complex128>(m_plotPts[n].rangeY[0], m_plotPts[n].rangeX[0]).imag()));
-                //            break;
-                //            case cmplxArg:
-                //                return QPointF(fPos, arg(m_pDataObj->at<ito::complex128>(m_plotPts[n].rangeY[0], m_plotPts[n].rangeX[0])));
-                //            break;
-                //        }
-                //    }
-    //                break;
-    //            }
-    //        }
-    //        else // if m_fast
-    //        {
-    //            double val;
-
-    //            switch(m_pDataObj->getType())
-    //            {
-    //                case ito::tInt8:
-    //                    val = m_pDataObj->at<int8>(m_plotPts[n].rangeY[0], m_plotPts[n].rangeX[0]) * m_plotPts[n].weights[0] +
-    //                        m_pDataObj->at<int8>(m_plotPts[n].rangeY[1], m_plotPts[n].rangeX[0]) * m_plotPts[n].weights[1] +
-    //                        m_pDataObj->at<int8>(m_plotPts[n].rangeY[1], m_plotPts[n].rangeX[1]) * m_plotPts[n].weights[2] +
-    //                        m_pDataObj->at<int8>(m_plotPts[n].rangeY[0], m_plotPts[n].rangeX[1]) * m_plotPts[n].weights[3];
-    //                break;
-    //                case ito::tUInt8:
-    //                    val = m_pDataObj->at<uint8>(m_plotPts[n].rangeY[0], m_plotPts[n].rangeX[0]) * m_plotPts[n].weights[0] +
-    //                        m_pDataObj->at<uint8>(m_plotPts[n].rangeY[1], m_plotPts[n].rangeX[0]) * m_plotPts[n].weights[1] +
-    //                        m_pDataObj->at<uint8>(m_plotPts[n].rangeY[1], m_plotPts[n].rangeX[1]) * m_plotPts[n].weights[2] +
-    //                        m_pDataObj->at<uint8>(m_plotPts[n].rangeY[0], m_plotPts[n].rangeX[1]) * m_plotPts[n].weights[3];
-    //                break;
-    //                case ito::tInt16:
-    //                    val = m_pDataObj->at<int16>(m_plotPts[n].rangeY[0], m_plotPts[n].rangeX[0]) * m_plotPts[n].weights[0] +
-    //                        m_pDataObj->at<int16>(m_plotPts[n].rangeY[1], m_plotPts[n].rangeX[0]) * m_plotPts[n].weights[1] +
-    //                        m_pDataObj->at<int16>(m_plotPts[n].rangeY[1], m_plotPts[n].rangeX[1]) * m_plotPts[n].weights[2] +
-    //                        m_pDataObj->at<int16>(m_plotPts[n].rangeY[0], m_plotPts[n].rangeX[1]) * m_plotPts[n].weights[3];
-    //                break;
-    //                case ito::tUInt16:
-    //                    val = m_pDataObj->at<uint16>(m_plotPts[n].rangeY[0], m_plotPts[n].rangeX[0]) * m_plotPts[n].weights[0] +
-    //                        m_pDataObj->at<uint16>(m_plotPts[n].rangeY[1], m_plotPts[n].rangeX[0]) * m_plotPts[n].weights[1] +
-    //                        m_pDataObj->at<uint16>(m_plotPts[n].rangeY[1], m_plotPts[n].rangeX[1]) * m_plotPts[n].weights[2] +
-    //                        m_pDataObj->at<uint16>(m_plotPts[n].rangeY[0], m_plotPts[n].rangeX[1]) * m_plotPts[n].weights[3];
-    //                break;
-    //                case ito::tInt32:
-    //                    val = m_pDataObj->at<int32>(m_plotPts[n].rangeY[0], m_plotPts[n].rangeX[0]) * m_plotPts[n].weights[0] +
-    //                        m_pDataObj->at<int32>(m_plotPts[n].rangeY[1], m_plotPts[n].rangeX[0]) * m_plotPts[n].weights[1] +
-    //                        m_pDataObj->at<int32>(m_plotPts[n].rangeY[1], m_plotPts[n].rangeX[1]) * m_plotPts[n].weights[2] +
-    //                        m_pDataObj->at<int32>(m_plotPts[n].rangeY[0], m_plotPts[n].rangeX[1]) * m_plotPts[n].weights[3];
-    //                break;
-    //                case ito::tUInt32:
-    //                    val = m_pDataObj->at<uint32>(m_plotPts[n].rangeY[0], m_plotPts[n].rangeX[0]) * m_plotPts[n].weights[0] +
-    //                        m_pDataObj->at<uint32>(m_plotPts[n].rangeY[1], m_plotPts[n].rangeX[0]) * m_plotPts[n].weights[1] +
-    //                        m_pDataObj->at<uint32>(m_plotPts[n].rangeY[1], m_plotPts[n].rangeX[1]) * m_plotPts[n].weights[2] +
-    //                        m_pDataObj->at<uint32>(m_plotPts[n].rangeY[0], m_plotPts[n].rangeX[1]) * m_plotPts[n].weights[3];
-    //                break;
-    //                case ito::tFloat32:
-    //                     val = m_pDataObj->at<float>(m_plotPts[n].rangeY[0], m_plotPts[n].rangeX[0]) * m_plotPts[n].weights[0] +
-    //                        m_pDataObj->at<float>(m_plotPts[n].rangeY[1], m_plotPts[n].rangeX[0]) * m_plotPts[n].weights[1] +
-    //                        m_pDataObj->at<float>(m_plotPts[n].rangeY[1], m_plotPts[n].rangeX[1]) * m_plotPts[n].weights[2] +
-    //                        m_pDataObj->at<float>(m_plotPts[n].rangeY[0], m_plotPts[n].rangeX[1]) * m_plotPts[n].weights[3];
-    //                break;
-    //                case ito::tFloat64:
-    //                     val = m_pDataObj->at<double>(m_plotPts[n].rangeY[0], m_plotPts[n].rangeX[0]) * m_plotPts[n].weights[0] +
-    //                        m_pDataObj->at<double>(m_plotPts[n].rangeY[1], m_plotPts[n].rangeX[0]) * m_plotPts[n].weights[1] +
-    //                        m_pDataObj->at<double>(m_plotPts[n].rangeY[1], m_plotPts[n].rangeX[1]) * m_plotPts[n].weights[2] +
-    //                        m_pDataObj->at<double>(m_plotPts[n].rangeY[0], m_plotPts[n].rangeX[1]) * m_plotPts[n].weights[3];
-    //                break;
-    //                case ito::tComplex64:
-                //    {
-                //        switch (m_cmplxState)
-                //        {
-                //            default:
-                //            case cmplxAbs:
-                //                rVal = m_pDataObj->at<ito::complex64>(m_plotPts[n].rangeY[0], m_plotPts[n].rangeX[0]).real() * m_plotPts[n].weights[0] +
-                //                    m_pDataObj->at<ito::complex64>(m_plotPts[n].rangeY[1], m_plotPts[n].rangeX[0]).real() * m_plotPts[n].weights[1] +
-                //                    m_pDataObj->at<ito::complex64>(m_plotPts[n].rangeY[1], m_plotPts[n].rangeX[1]).real() * m_plotPts[n].weights[2] +
-                //                    m_pDataObj->at<ito::complex64>(m_plotPts[n].rangeY[0], m_plotPts[n].rangeX[1]).real() * m_plotPts[n].weights[3];
-                //                iVal = m_pDataObj->at<ito::complex64>(m_plotPts[n].rangeY[0], m_plotPts[n].rangeX[0]).imag() * m_plotPts[n].weights[0] +
-                //                    m_pDataObj->at<ito::complex64>(m_plotPts[n].rangeY[1], m_plotPts[n].rangeX[0]).imag() * m_plotPts[n].weights[1] +
-                //                    m_pDataObj->at<ito::complex64>(m_plotPts[n].rangeY[1], m_plotPts[n].rangeX[1]).imag() * m_plotPts[n].weights[2] +
-                //                    m_pDataObj->at<ito::complex64>(m_plotPts[n].rangeY[0], m_plotPts[n].rangeX[1]).imag() * m_plotPts[n].weights[3];
-                //                val = sqrt(rVal * rVal + iVal * iVal);
-                //            break;
-                //            case cmplxReal:
-                //                val = m_pDataObj->at<ito::complex64>(m_plotPts[n].rangeY[0], m_plotPts[n].rangeX[0]).real() * m_plotPts[n].weights[0] +
-                //                    m_pDataObj->at<ito::complex64>(m_plotPts[n].rangeY[1], m_plotPts[n].rangeX[0]).real() * m_plotPts[n].weights[1] +
-                //                    m_pDataObj->at<ito::complex64>(m_plotPts[n].rangeY[1], m_plotPts[n].rangeX[1]).real() * m_plotPts[n].weights[2] +
-                //                    m_pDataObj->at<ito::complex64>(m_plotPts[n].rangeY[0], m_plotPts[n].rangeX[1]).real() * m_plotPts[n].weights[3];
-                //            break;
-                //            case cmplxImag:
-                //                val = m_pDataObj->at<ito::complex64>(m_plotPts[n].rangeY[0], m_plotPts[n].rangeX[0]).imag() * m_plotPts[n].weights[0] +
-                //                    m_pDataObj->at<ito::complex64>(m_plotPts[n].rangeY[1], m_plotPts[n].rangeX[0]).imag() * m_plotPts[n].weights[1] +
-                //                    m_pDataObj->at<ito::complex64>(m_plotPts[n].rangeY[1], m_plotPts[n].rangeX[1]).imag() * m_plotPts[n].weights[2] +
-                //                    m_pDataObj->at<ito::complex64>(m_plotPts[n].rangeY[0], m_plotPts[n].rangeX[1]).imag() * m_plotPts[n].weights[3];
-                //            break;
-                //            case cmplxArg:
-                //                rVal = m_pDataObj->at<ito::complex64>(m_plotPts[n].rangeY[0], m_plotPts[n].rangeX[0]).real() * m_plotPts[n].weights[0] +
-                //                    m_pDataObj->at<ito::complex64>(m_plotPts[n].rangeY[1], m_plotPts[n].rangeX[0]).real() * m_plotPts[n].weights[1] +
-                //                    m_pDataObj->at<ito::complex64>(m_plotPts[n].rangeY[1], m_plotPts[n].rangeX[1]).real() * m_plotPts[n].weights[2] +
-                //                    m_pDataObj->at<ito::complex64>(m_plotPts[n].rangeY[0], m_plotPts[n].rangeX[1]).real() * m_plotPts[n].weights[3];
-                //                iVal = m_pDataObj->at<ito::complex64>(m_plotPts[n].rangeY[0], m_plotPts[n].rangeX[0]).imag() * m_plotPts[n].weights[0] +
-                //                    m_pDataObj->at<ito::complex64>(m_plotPts[n].rangeY[1], m_plotPts[n].rangeX[0]).imag() * m_plotPts[n].weights[1] +
-                //                    m_pDataObj->at<ito::complex64>(m_plotPts[n].rangeY[1], m_plotPts[n].rangeX[1]).imag() * m_plotPts[n].weights[2] +
-                //                    m_pDataObj->at<ito::complex64>(m_plotPts[n].rangeY[0], m_plotPts[n].rangeX[1]).imag() * m_plotPts[n].weights[3];
-                //                val = atan2(iVal, rVal);
-                //            break;
-                //        }
-                //    }
-    //                break;
-    //                case ito::tComplex128:
-                //    {
-                //        switch (m_cmplxState)
-                //        {
-                //            default:
-                //            case cmplxAbs:
-                //                rVal = m_pDataObj->at<ito::complex128>(m_plotPts[n].rangeY[0], m_plotPts[n].rangeX[0]).real() * m_plotPts[n].weights[0] +
-                //                    m_pDataObj->at<ito::complex128>(m_plotPts[n].rangeY[1], m_plotPts[n].rangeX[0]).real() * m_plotPts[n].weights[1] +
-                //                    m_pDataObj->at<ito::complex128>(m_plotPts[n].rangeY[1], m_plotPts[n].rangeX[1]).real() * m_plotPts[n].weights[2] +
-                //                    m_pDataObj->at<ito::complex128>(m_plotPts[n].rangeY[0], m_plotPts[n].rangeX[1]).real() * m_plotPts[n].weights[3];
-                //                iVal = m_pDataObj->at<ito::complex128>(m_plotPts[n].rangeY[0], m_plotPts[n].rangeX[0]).imag() * m_plotPts[n].weights[0] +
-                //                    m_pDataObj->at<ito::complex128>(m_plotPts[n].rangeY[1], m_plotPts[n].rangeX[0]).imag() * m_plotPts[n].weights[1] +
-                //                    m_pDataObj->at<ito::complex128>(m_plotPts[n].rangeY[1], m_plotPts[n].rangeX[1]).imag() * m_plotPts[n].weights[2] +
-                //                    m_pDataObj->at<ito::complex128>(m_plotPts[n].rangeY[0], m_plotPts[n].rangeX[1]).imag() * m_plotPts[n].weights[3];
-                //                val = sqrt(rVal * rVal + iVal * iVal);
-                //            break;
-                //            case cmplxReal:
-                //                val = m_pDataObj->at<ito::complex128>(m_plotPts[n].rangeY[0], m_plotPts[n].rangeX[0]).real() * m_plotPts[n].weights[0] +
-                //                    m_pDataObj->at<ito::complex128>(m_plotPts[n].rangeY[1], m_plotPts[n].rangeX[0]).real() * m_plotPts[n].weights[1] +
-                //                    m_pDataObj->at<ito::complex128>(m_plotPts[n].rangeY[1], m_plotPts[n].rangeX[1]).real() * m_plotPts[n].weights[2] +
-                //                    m_pDataObj->at<ito::complex128>(m_plotPts[n].rangeY[0], m_plotPts[n].rangeX[1]).real() * m_plotPts[n].weights[3];
-                //            break;
-                //            case cmplxImag:
-                //                val = m_pDataObj->at<ito::complex128>(m_plotPts[n].rangeY[0], m_plotPts[n].rangeX[0]).imag() * m_plotPts[n].weights[0] +
-                //                    m_pDataObj->at<ito::complex128>(m_plotPts[n].rangeY[1], m_plotPts[n].rangeX[0]).imag() * m_plotPts[n].weights[1] +
-                //                    m_pDataObj->at<ito::complex128>(m_plotPts[n].rangeY[1], m_plotPts[n].rangeX[1]).imag() * m_plotPts[n].weights[2] +
-                //                    m_pDataObj->at<ito::complex128>(m_plotPts[n].rangeY[0], m_plotPts[n].rangeX[1]).imag() * m_plotPts[n].weights[3];
-                //            break;
-    //                        case cmplxArg:
-                //                rVal = m_pDataObj->at<ito::complex128>(m_plotPts[n].rangeY[0], m_plotPts[n].rangeX[0]).real() * m_plotPts[n].weights[0] +
-                //                    m_pDataObj->at<ito::complex128>(m_plotPts[n].rangeY[1], m_plotPts[n].rangeX[0]).real() * m_plotPts[n].weights[1] +
-                //                    m_pDataObj->at<ito::complex128>(m_plotPts[n].rangeY[1], m_plotPts[n].rangeX[1]).real() * m_plotPts[n].weights[2] +
-                //                    m_pDataObj->at<ito::complex128>(m_plotPts[n].rangeY[0], m_plotPts[n].rangeX[1]).real() * m_plotPts[n].weights[3];
-                //                iVal = m_pDataObj->at<ito::complex128>(m_plotPts[n].rangeY[0], m_plotPts[n].rangeX[0]).imag() * m_plotPts[n].weights[0] +
-                //                    m_pDataObj->at<ito::complex128>(m_plotPts[n].rangeY[1], m_plotPts[n].rangeX[0]).imag() * m_plotPts[n].weights[1] +
-                //                    m_pDataObj->at<ito::complex128>(m_plotPts[n].rangeY[1], m_plotPts[n].rangeX[1]).imag() * m_plotPts[n].weights[2] +
-                //                    m_pDataObj->at<ito::complex128>(m_plotPts[n].rangeY[0], m_plotPts[n].rangeX[1]).imag() * m_plotPts[n].weights[3];
-                //                val = atan2(iVal, rVal);
-                //            break;
-                //        }
-                //    }
-    //                break;
-    //            }
-    //            return QPointF(fPos, val);
-    //        }
-    //    }
-    //    else if (m_zDirect)
-    //    {
-
-    //        ito::DataObject tempObj = *m_pDataObj;
-    //        int dataObjectDims = tempObj.getDims();
-    //        int* limits = new int[2*dataObjectDims];
-    //        memset(limits, 0, sizeof(int) * 2*dataObjectDims);
-
-    //        tempObj.locateROI(limits);
-
-    //        limits[2*(dataObjectDims - 3)] *= -1;
-    //        limits[2*(dataObjectDims - 3) + 1] *= -1;
-
-    //        tempObj.adjustROI(dataObjectDims,limits);
-    //        delete limits;
-
-    //        double fPos;
-
-    //        if (m_Scaling > 0) fPos = n * m_Scaling + m_startPos;
-    //        else fPos = n * abs(m_Scaling) + m_startPos  + m_physLength;
-
-    //        cv::Mat* curPlane = (cv::Mat*)tempObj.get_mdata()[tempObj.seekMat(n)];
-    //        switch(m_pDataObj->getType())
-    //        {
-    //            case ito::tInt8:
-    //                return QPointF(fPos, curPlane->at<int8>(m_plotPts[n].rangeY[0], m_plotPts[n].rangeX[0]));
-    //            break;
-    //            case ito::tUInt8:
-    //                return QPointF(fPos, curPlane->at<uint8>(m_plotPts[n].rangeY[0], m_plotPts[n].rangeX[0]));
-    //            break;
-    //            case ito::tInt16:
-    //                return QPointF(fPos, curPlane->at<int16>(m_plotPts[n].rangeY[0], m_plotPts[n].rangeX[0]));
-    //            break;
-    //            case ito::tUInt16:
-    //                return QPointF(fPos, curPlane->at<uint16>(m_plotPts[n].rangeY[0], m_plotPts[n].rangeX[0]));
-    //            break;
-    //            case ito::tInt32:
-    //                return QPointF(fPos, curPlane->at<int32>(m_plotPts[n].rangeY[0], m_plotPts[n].rangeX[0]));
-    //            break;
-    //            case ito::tUInt32:
-    //                return QPointF(fPos, curPlane->at<uint32>(m_plotPts[n].rangeY[0], m_plotPts[n].rangeX[0]));
-    //            break;
-    //            case ito::tFloat32:
-    //                return QPointF(fPos, curPlane->at<float>(m_plotPts[n].rangeY[0], m_plotPts[n].rangeX[0]));
-    //            break;
-    //            case ito::tFloat64:
-    //                return QPointF(fPos, curPlane->at<double>(m_plotPts[n].rangeY[0], m_plotPts[n].rangeX[0]));
-    //            break;
-    //            case ito::tComplex64:
-                //{
-                //    switch (m_cmplxState)
-                //    {
-                //        default:
-                //        case cmplxAbs:
-                //            return QPointF(fPos, abs(curPlane->at<ito::complex64>(m_plotPts[n].rangeY[0], m_plotPts[n].rangeX[0])));
-                //        break;
-                //        case cmplxReal:
-                //            return QPointF(fPos, (curPlane->at<ito::complex64>(m_plotPts[n].rangeY[0], m_plotPts[n].rangeX[0]).real()));
-                //        break;
-                //        case cmplxImag:
-                //            return QPointF(fPos, (curPlane->at<ito::complex64>(m_plotPts[n].rangeY[0], m_plotPts[n].rangeX[0]).imag()));
-                //        break;
-                //        case cmplxArg:
-                //            return QPointF(fPos, arg(curPlane->at<ito::complex64>(m_plotPts[n].rangeY[0], m_plotPts[n].rangeX[0])));
-                //        break;
-                //    }
-                //}
-    //            break;
-    //            case ito::tComplex128:
-                //{
-                //    switch (m_cmplxState)
-                //    {
-                //        default:
-                //        case cmplxAbs:
-                //            return QPointF(fPos, abs(curPlane->at<ito::complex128>(m_plotPts[n].rangeY[0], m_plotPts[n].rangeX[0])));
-                //        break;
-                //        case cmplxReal:
-                //            return QPointF(fPos, (curPlane->at<ito::complex128>(m_plotPts[n].rangeY[0], m_plotPts[n].rangeX[0]).real()));
-                //        break;
-                //        case cmplxImag:
-                //            return QPointF(fPos, (curPlane->at<ito::complex128>(m_plotPts[n].rangeY[0], m_plotPts[n].rangeX[0]).imag()));
-                //        break;
-                //        case cmplxArg:
-                //            return QPointF(fPos, arg(curPlane->at<ito::complex128>(m_plotPts[n].rangeY[0], m_plotPts[n].rangeX[0])));
-                //        break;
-                //    }
-                //}
-    //            break;
-    //        }
-    //        return QPointF();
-    //    } // if m_zDirect
-    //    else
-    //    {
-    //        double fPos;
-
-    //        if (m_Scaling > 0) fPos = n * m_Scaling + m_startPos;
-    //        else fPos = n * abs(m_Scaling) + m_startPos  + m_physLength;
-
-    //        cv::Mat* curPlane = (cv::Mat*)m_pDataObj->get_mdata()[m_pDataObj->seekMat(0)];
-    //        if (m_fast)
-    //        {
-    //            switch(m_pDataObj->getType())
-    //            {
-    //                case ito::tInt8:
-    //                    return QPointF(fPos, curPlane->at<int8>(m_plotPts[n].rangeY[0], m_plotPts[n].rangeX[0]));
-    //                break;
-    //                case ito::tUInt8:
-    //                    return QPointF(fPos, curPlane->at<uint8>(m_plotPts[n].rangeY[0], m_plotPts[n].rangeX[0]));
-    //                break;
-    //                case ito::tInt16:
-    //                    return QPointF(fPos, curPlane->at<int16>(m_plotPts[n].rangeY[0], m_plotPts[n].rangeX[0]));
-    //                break;
-    //                case ito::tUInt16:
-    //                    return QPointF(fPos, curPlane->at<uint16>(m_plotPts[n].rangeY[0], m_plotPts[n].rangeX[0]));
-    //                break;
-    //                case ito::tInt32:
-    //                    return QPointF(fPos, curPlane->at<int32>(m_plotPts[n].rangeY[0], m_plotPts[n].rangeX[0]));
-    //                break;
-    //                case ito::tUInt32:
-    //                    return QPointF(fPos, curPlane->at<uint32>(m_plotPts[n].rangeY[0], m_plotPts[n].rangeX[0]));
-    //                break;
-    //                case ito::tFloat32:
-    //                    return QPointF(fPos, curPlane->at<float>(m_plotPts[n].rangeY[0], m_plotPts[n].rangeX[0]));
-    //                break;
-    //                case ito::tFloat64:
-    //                    return QPointF(fPos, curPlane->at<double>(m_plotPts[n].rangeY[0], m_plotPts[n].rangeX[0]));
-    //                break;
-                //    case ito::tComplex64:
-                //    {
-                //        switch (m_cmplxState)
-                //        {
-                //            default:
-                //            case cmplxAbs:
-                //                return QPointF(fPos, abs(curPlane->at<ito::complex64>(m_plotPts[n].rangeY[0], m_plotPts[n].rangeX[0])));
-                //            break;
-                //            case cmplxReal:
-                //                return QPointF(fPos, (curPlane->at<ito::complex64>(m_plotPts[n].rangeY[0], m_plotPts[n].rangeX[0]).real()));
-                //            break;
-                //            case cmplxImag:
-                //                return QPointF(fPos, (curPlane->at<ito::complex64>(m_plotPts[n].rangeY[0], m_plotPts[n].rangeX[0]).imag()));
-                //            break;
-                //            case cmplxArg:
-                //                return QPointF(fPos, arg(curPlane->at<ito::complex64>(m_plotPts[n].rangeY[0], m_plotPts[n].rangeX[0])));
-                //            break;
-                //        }
-                //    }
-                //    break;
-                //    case ito::tComplex128:
-                //    {
-                //        switch (m_cmplxState)
-                //        {
-                //            default:
-                //            case cmplxAbs:
-                //                return QPointF(fPos, abs(curPlane->at<ito::complex128>(m_plotPts[n].rangeY[0], m_plotPts[n].rangeX[0])));
-                //            break;
-                //            case cmplxReal:
-                //                return QPointF(fPos, (curPlane->at<ito::complex128>(m_plotPts[n].rangeY[0], m_plotPts[n].rangeX[0]).real()));
-                //            break;
-                //            case cmplxImag:
-                //                return QPointF(fPos, (curPlane->at<ito::complex128>(m_plotPts[n].rangeY[0], m_plotPts[n].rangeX[0]).imag()));
-                //            break;
-                //            case cmplxArg:
-                //                return QPointF(fPos, arg(curPlane->at<ito::complex128>(m_plotPts[n].rangeY[0], m_plotPts[n].rangeX[0])));
-                //            break;
-                //        }
-                //    }
-                //    break;
-    //            }
-    //        } // if m_fast
-    //        else
-    //        {
-    //            double val;
-
-    //            switch(m_pDataObj->getType())
-    //            {
-    //                case ito::tInt8:
-    //                    val = curPlane->at<int8>(m_plotPts[n].rangeY[0], m_plotPts[n].rangeX[0]) * m_plotPts[n].weights[0] +
-    //                        curPlane->at<int8>(m_plotPts[n].rangeY[1], m_plotPts[n].rangeX[0]) * m_plotPts[n].weights[1] +
-    //                        curPlane->at<int8>(m_plotPts[n].rangeY[1], m_plotPts[n].rangeX[1]) * m_plotPts[n].weights[2] +
-    //                        curPlane->at<int8>(m_plotPts[n].rangeY[0], m_plotPts[n].rangeX[1]) * m_plotPts[n].weights[3];
-    //                break;
-    //                case ito::tUInt8:
-    //                    val = curPlane->at<uint8>(m_plotPts[n].rangeY[0], m_plotPts[n].rangeX[0]) * m_plotPts[n].weights[0] +
-    //                        curPlane->at<uint8>(m_plotPts[n].rangeY[1], m_plotPts[n].rangeX[0]) * m_plotPts[n].weights[1] +
-    //                        curPlane->at<uint8>(m_plotPts[n].rangeY[1], m_plotPts[n].rangeX[1]) * m_plotPts[n].weights[2] +
-    //                        curPlane->at<uint8>(m_plotPts[n].rangeY[0], m_plotPts[n].rangeX[1]) * m_plotPts[n].weights[3];
-    //                break;
-    //                case ito::tInt16:
-    //                    val = curPlane->at<int16>(m_plotPts[n].rangeY[0], m_plotPts[n].rangeX[0]) * m_plotPts[n].weights[0] +
-    //                        curPlane->at<int16>(m_plotPts[n].rangeY[1], m_plotPts[n].rangeX[0]) * m_plotPts[n].weights[1] +
-    //                        curPlane->at<int16>(m_plotPts[n].rangeY[1], m_plotPts[n].rangeX[1]) * m_plotPts[n].weights[2] +
-    //                        curPlane->at<int16>(m_plotPts[n].rangeY[0], m_plotPts[n].rangeX[1]) * m_plotPts[n].weights[3];
-    //                break;
-    //                case ito::tUInt16:
-    //                    val = curPlane->at<uint16>(m_plotPts[n].rangeY[0], m_plotPts[n].rangeX[0]) * m_plotPts[n].weights[0] +
-    //                        curPlane->at<uint16>(m_plotPts[n].rangeY[1], m_plotPts[n].rangeX[0]) * m_plotPts[n].weights[1] +
-    //                        curPlane->at<uint16>(m_plotPts[n].rangeY[1], m_plotPts[n].rangeX[1]) * m_plotPts[n].weights[2] +
-    //                        curPlane->at<uint16>(m_plotPts[n].rangeY[0], m_plotPts[n].rangeX[1]) * m_plotPts[n].weights[3];
-    //                break;
-    //                case ito::tInt32:
-    //                    val = curPlane->at<int32>(m_plotPts[n].rangeY[0], m_plotPts[n].rangeX[0]) * m_plotPts[n].weights[0] +
-    //                        curPlane->at<int32>(m_plotPts[n].rangeY[1], m_plotPts[n].rangeX[0]) * m_plotPts[n].weights[1] +
-    //                        curPlane->at<int32>(m_plotPts[n].rangeY[1], m_plotPts[n].rangeX[1]) * m_plotPts[n].weights[2] +
-    //                        curPlane->at<int32>(m_plotPts[n].rangeY[0], m_plotPts[n].rangeX[1]) * m_plotPts[n].weights[3];
-    //                break;
-    //                case ito::tUInt32:
-    //                    val = curPlane->at<uint32>(m_plotPts[n].rangeY[0], m_plotPts[n].rangeX[0]) * m_plotPts[n].weights[0] +
-    //                        curPlane->at<uint32>(m_plotPts[n].rangeY[1], m_plotPts[n].rangeX[0]) * m_plotPts[n].weights[1] +
-    //                        curPlane->at<uint32>(m_plotPts[n].rangeY[1], m_plotPts[n].rangeX[1]) * m_plotPts[n].weights[2] +
-    //                        curPlane->at<uint32>(m_plotPts[n].rangeY[0], m_plotPts[n].rangeX[1]) * m_plotPts[n].weights[3];
-    //                break;
-    //                case ito::tFloat32:
-    //                     val = curPlane->at<float>(m_plotPts[n].rangeY[0], m_plotPts[n].rangeX[0]) * m_plotPts[n].weights[0] +
-    //                        curPlane->at<float>(m_plotPts[n].rangeY[1], m_plotPts[n].rangeX[0]) * m_plotPts[n].weights[1] +
-    //                        curPlane->at<float>(m_plotPts[n].rangeY[1], m_plotPts[n].rangeX[1]) * m_plotPts[n].weights[2] +
-    //                        curPlane->at<float>(m_plotPts[n].rangeY[0], m_plotPts[n].rangeX[1]) * m_plotPts[n].weights[3];
-    //                break;
-    //                case ito::tFloat64:
-    //                     val = curPlane->at<double>(m_plotPts[n].rangeY[0], m_plotPts[n].rangeX[0]) * m_plotPts[n].weights[0] +
-    //                        curPlane->at<double>(m_plotPts[n].rangeY[1], m_plotPts[n].rangeX[0]) * m_plotPts[n].weights[1] +
-    //                        curPlane->at<double>(m_plotPts[n].rangeY[1], m_plotPts[n].rangeX[1]) * m_plotPts[n].weights[2] +
-    //                        curPlane->at<double>(m_plotPts[n].rangeY[0], m_plotPts[n].rangeX[1]) * m_plotPts[n].weights[3];
-    //                break;
-                //    case ito::tComplex64:
-                //    {
-                //        switch (m_cmplxState)
-                //        {
-                //            default:
-                //            case cmplxAbs:
-                //                rVal = curPlane->at<ito::complex64>(m_plotPts[n].rangeY[0], m_plotPts[n].rangeX[0]).real() * m_plotPts[n].weights[0] +
-                //                    curPlane->at<ito::complex64>(m_plotPts[n].rangeY[1], m_plotPts[n].rangeX[0]).real() * m_plotPts[n].weights[1] +
-                //                    curPlane->at<ito::complex64>(m_plotPts[n].rangeY[1], m_plotPts[n].rangeX[1]).real() * m_plotPts[n].weights[2] +
-                //                    curPlane->at<ito::complex64>(m_plotPts[n].rangeY[0], m_plotPts[n].rangeX[1]).real() * m_plotPts[n].weights[3];
-                //                iVal = curPlane->at<ito::complex64>(m_plotPts[n].rangeY[0], m_plotPts[n].rangeX[0]).imag() * m_plotPts[n].weights[0] +
-                //                    curPlane->at<ito::complex64>(m_plotPts[n].rangeY[1], m_plotPts[n].rangeX[0]).imag() * m_plotPts[n].weights[1] +
-                //                    curPlane->at<ito::complex64>(m_plotPts[n].rangeY[1], m_plotPts[n].rangeX[1]).imag() * m_plotPts[n].weights[2] +
-                //                    curPlane->at<ito::complex64>(m_plotPts[n].rangeY[0], m_plotPts[n].rangeX[1]).imag() * m_plotPts[n].weights[3];
-                //                val = sqrt(rVal * rVal + iVal * iVal);
-                //            break;
-                //            case cmplxReal:
-                //                val = curPlane->at<ito::complex64>(m_plotPts[n].rangeY[0], m_plotPts[n].rangeX[0]).real() * m_plotPts[n].weights[0] +
-                //                    curPlane->at<ito::complex64>(m_plotPts[n].rangeY[1], m_plotPts[n].rangeX[0]).real() * m_plotPts[n].weights[1] +
-                //                    curPlane->at<ito::complex64>(m_plotPts[n].rangeY[1], m_plotPts[n].rangeX[1]).real() * m_plotPts[n].weights[2] +
-                //                    curPlane->at<ito::complex64>(m_plotPts[n].rangeY[0], m_plotPts[n].rangeX[1]).real() * m_plotPts[n].weights[3];
-                //            break;
-                //            case cmplxImag:
-                //                val = curPlane->at<ito::complex64>(m_plotPts[n].rangeY[0], m_plotPts[n].rangeX[0]).imag() * m_plotPts[n].weights[0] +
-                //                    curPlane->at<ito::complex64>(m_plotPts[n].rangeY[1], m_plotPts[n].rangeX[0]).imag() * m_plotPts[n].weights[1] +
-                //                    curPlane->at<ito::complex64>(m_plotPts[n].rangeY[1], m_plotPts[n].rangeX[1]).imag() * m_plotPts[n].weights[2] +
-                //                    curPlane->at<ito::complex64>(m_plotPts[n].rangeY[0], m_plotPts[n].rangeX[1]).imag() * m_plotPts[n].weights[3];
-                //            break;
-                //            case cmplxArg:
-                //                rVal = curPlane->at<ito::complex64>(m_plotPts[n].rangeY[0], m_plotPts[n].rangeX[0]).real() * m_plotPts[n].weights[0] +
-                //                    curPlane->at<ito::complex64>(m_plotPts[n].rangeY[1], m_plotPts[n].rangeX[0]).real() * m_plotPts[n].weights[1] +
-                //                    curPlane->at<ito::complex64>(m_plotPts[n].rangeY[1], m_plotPts[n].rangeX[1]).real() * m_plotPts[n].weights[2] +
-                //                    curPlane->at<ito::complex64>(m_plotPts[n].rangeY[0], m_plotPts[n].rangeX[1]).real() * m_plotPts[n].weights[3];
-                //                iVal = curPlane->at<ito::complex64>(m_plotPts[n].rangeY[0], m_plotPts[n].rangeX[0]).imag() * m_plotPts[n].weights[0] +
-                //                    curPlane->at<ito::complex64>(m_plotPts[n].rangeY[1], m_plotPts[n].rangeX[0]).imag() * m_plotPts[n].weights[1] +
-                //                    curPlane->at<ito::complex64>(m_plotPts[n].rangeY[1], m_plotPts[n].rangeX[1]).imag() * m_plotPts[n].weights[2] +
-                //                    curPlane->at<ito::complex64>(m_plotPts[n].rangeY[0], m_plotPts[n].rangeX[1]).imag() * m_plotPts[n].weights[3];
-                //                val = atan2(iVal, rVal);
-                //            break;
-                //        }
-                //    }
-                //    break;
-                //    case ito::tComplex128:
-                //    {
-                //        switch (m_cmplxState)
-                //        {
-                //            default:
-                //            case cmplxAbs:
-                //                rVal = curPlane->at<ito::complex128>(m_plotPts[n].rangeY[0], m_plotPts[n].rangeX[0]).real() * m_plotPts[n].weights[0] +
-                //                    curPlane->at<ito::complex128>(m_plotPts[n].rangeY[1], m_plotPts[n].rangeX[0]).real() * m_plotPts[n].weights[1] +
-                //                    curPlane->at<ito::complex128>(m_plotPts[n].rangeY[1], m_plotPts[n].rangeX[1]).real() * m_plotPts[n].weights[2] +
-                //                    curPlane->at<ito::complex128>(m_plotPts[n].rangeY[0], m_plotPts[n].rangeX[1]).real() * m_plotPts[n].weights[3];
-                //                iVal = curPlane->at<ito::complex128>(m_plotPts[n].rangeY[0], m_plotPts[n].rangeX[0]).imag() * m_plotPts[n].weights[0] +
-                //                    curPlane->at<ito::complex128>(m_plotPts[n].rangeY[1], m_plotPts[n].rangeX[0]).imag() * m_plotPts[n].weights[1] +
-                //                    curPlane->at<ito::complex128>(m_plotPts[n].rangeY[1], m_plotPts[n].rangeX[1]).imag() * m_plotPts[n].weights[2] +
-                //                    curPlane->at<ito::complex128>(m_plotPts[n].rangeY[0], m_plotPts[n].rangeX[1]).imag() * m_plotPts[n].weights[3];
-                //                val = sqrt(rVal * rVal + iVal * iVal);
-                //            break;
-                //            case cmplxReal:
-                //                val = curPlane->at<ito::complex128>(m_plotPts[n].rangeY[0], m_plotPts[n].rangeX[0]).real() * m_plotPts[n].weights[0] +
-                //                    curPlane->at<ito::complex128>(m_plotPts[n].rangeY[1], m_plotPts[n].rangeX[0]).real() * m_plotPts[n].weights[1] +
-                //                    curPlane->at<ito::complex128>(m_plotPts[n].rangeY[1], m_plotPts[n].rangeX[1]).real() * m_plotPts[n].weights[2] +
-                //                    curPlane->at<ito::complex128>(m_plotPts[n].rangeY[0], m_plotPts[n].rangeX[1]).real() * m_plotPts[n].weights[3];
-                //            break;
-                //            case cmplxImag:
-                //                val = curPlane->at<ito::complex128>(m_plotPts[n].rangeY[0], m_plotPts[n].rangeX[0]).imag() * m_plotPts[n].weights[0] +
-                //                    curPlane->at<ito::complex128>(m_plotPts[n].rangeY[1], m_plotPts[n].rangeX[0]).imag() * m_plotPts[n].weights[1] +
-                //                    curPlane->at<ito::complex128>(m_plotPts[n].rangeY[1], m_plotPts[n].rangeX[1]).imag() * m_plotPts[n].weights[2] +
-                //                    curPlane->at<ito::complex128>(m_plotPts[n].rangeY[0], m_plotPts[n].rangeX[1]).imag() * m_plotPts[n].weights[3];
-                //            break;
-                //            case cmplxArg:
-                //                rVal = curPlane->at<ito::complex128>(m_plotPts[n].rangeY[0], m_plotPts[n].rangeX[0]).real() * m_plotPts[n].weights[0] +
-                //                    curPlane->at<ito::complex128>(m_plotPts[n].rangeY[1], m_plotPts[n].rangeX[0]).real() * m_plotPts[n].weights[1] +
-                //                    curPlane->at<ito::complex128>(m_plotPts[n].rangeY[1], m_plotPts[n].rangeX[1]).real() * m_plotPts[n].weights[2] +
-                //                    curPlane->at<ito::complex128>(m_plotPts[n].rangeY[0], m_plotPts[n].rangeX[1]).real() * m_plotPts[n].weights[3];
-                //                iVal = curPlane->at<ito::complex128>(m_plotPts[n].rangeY[0], m_plotPts[n].rangeX[0]).imag() * m_plotPts[n].weights[0] +
-                //                    curPlane->at<ito::complex128>(m_plotPts[n].rangeY[1], m_plotPts[n].rangeX[0]).imag() * m_plotPts[n].weights[1] +
-                //                    curPlane->at<ito::complex128>(m_plotPts[n].rangeY[1], m_plotPts[n].rangeX[1]).imag() * m_plotPts[n].weights[2] +
-                //                    curPlane->at<ito::complex128>(m_plotPts[n].rangeY[0], m_plotPts[n].rangeX[1]).imag() * m_plotPts[n].weights[3];
-                //                val = atan2(iVal, rVal);
-                //            break;
-                //        }
-                //    }
-                //    break;
-    //            }
-    //            return QPointF(fPos, val);
-    //        }
-    //    }
-    //}
-    //return QPointF();
 }
 
 //----------------------------------------------------------------------------------------------------------------------------------

--- a/itom1DQwtPlot/plot1DWidget.cpp
+++ b/itom1DQwtPlot/plot1DWidget.cpp
@@ -1889,15 +1889,16 @@ void Plot1DWidget::refreshPlot(const ito::DataObject* dataObj, QVector<QPointF> 
                 }
                 if (seriesData && seriesData->isDobjInit())
                 {
-                    seriesData->updateDataObject(dataObj, tmpBounds);
+                    retval += seriesData->updateDataObject(dataObj, tmpBounds);
                 }
                 else
                 {
                     seriesData = new DataObjectSeriesData(1);
-                    seriesData->updateDataObject(dataObj, tmpBounds);
+                    retval += seriesData->updateDataObject(dataObj, tmpBounds);
                     seriesData->setCmplxState(m_pComplexStyle);
                     m_plotCurveItems[n]->setData(seriesData);
                 }
+
                 if (m_pData->m_dataType == ito::tRGBA32)
                 {
                     if (m_pData->m_colorLine == ItomQwtPlotEnums::Gray)
@@ -1912,6 +1913,11 @@ void Plot1DWidget::refreshPlot(const ito::DataObject* dataObj, QVector<QPointF> 
                     {
                         seriesData->setColorState(n == 3 ? 4 : n);
                     }
+                }
+
+                if (retval.containsWarningOrError())
+                {
+                    emit statusBarMessage(QLatin1String(retval.errorMessage()), 5000);
                 }
             }
 
@@ -1929,14 +1935,19 @@ void Plot1DWidget::refreshPlot(const ito::DataObject* dataObj, QVector<QPointF> 
                 seriesData = static_cast<DataObjectSeriesData*>(m_plotCurveItems[n]->data());
                 if (seriesData && seriesData->isDobjInit())
                 {
-                    seriesData->updateDataObject(dataObj, bounds);
+                    retval += seriesData->updateDataObject(dataObj, bounds);
                 }
                 else
                 {
                     seriesData = new DataObjectSeriesData(1);
-                    seriesData->updateDataObject(dataObj, bounds);
+                    retval += seriesData->updateDataObject(dataObj, bounds);
                     seriesData->setCmplxState(m_pComplexStyle);
                     m_plotCurveItems[n]->setData(seriesData);
+                }
+
+                if (retval.containsWarningOrError())
+                {
+                    emit statusBarMessage(QLatin1String(retval.errorMessage()), 5000);
                 }
 
                 if (m_pData->m_dataType == ito::tRGBA32)

--- a/itom2DQwtPlot/itom2dqwtplot.cpp
+++ b/itom2DQwtPlot/itom2dqwtplot.cpp
@@ -1,7 +1,7 @@
 /* ********************************************************************
    itom measurement system
    URL: http://www.uni-stuttgart.de/ito
-   Copyright (C) 2019, Institut für Technische Optik (ITO),
+   Copyright (C) 2025, Institut für Technische Optik (ITO),
    Universität Stuttgart, Germany
 
    This file is part of itom.
@@ -881,8 +881,13 @@ void Itom2dQwtPlot::resetDataChannel()
     updatePropertyDock();
 }
 
-//----------------------------------------------------------------------------------------------------------------------------------
-void Itom2dQwtPlot::setPlaneRange(int min, int max)
+//-------------------------------------------------------------------------------------
+/*
+* \param stackAndVolumeCutAllowed should be set to true if for a dim > 2 dataObject only
+*     one of the first dim-2 dimensions has a size != 1. Else, it is not possible to make
+*     a zCut or volumeCut.
+*/
+void Itom2dQwtPlot::setPlaneRange(int min, int max, bool stackAndVolumeCutAllowed)
 {
     if (m_pContent)
     {
@@ -899,6 +904,8 @@ void Itom2dQwtPlot::setPlaneRange(int min, int max)
         m_pContent->m_pActPlaneSelector->setVisible((max - min) > 0);
         m_pContent->m_pActStackCut->setVisible((max - min) > 0);
         m_pContent->m_pActVolumeCut->setVisible((max - min) > 0);
+        m_pContent->m_pActStackCut->setEnabled(stackAndVolumeCutAllowed);
+        m_pContent->m_pActVolumeCut->setEnabled(stackAndVolumeCutAllowed);
     }
 }
 
@@ -981,7 +988,12 @@ ito::RetVal Itom2dQwtPlot::displayVolumeCut(const QVector<QPointF> &bounds, ito:
                 ((QMainWindow*)childFigure)->setWindowTitle(tr("Volumecut"));
                 if (childFigure->inherits("ItomQwtDObjFigure"))
                 {
-                    ((ItomQwtDObjFigure*)childFigure)->setComplexStyle(d->m_pData->m_cmplxType);
+                    ItomQwtDObjFigure* itomChildFigure = (ItomQwtDObjFigure*)childFigure;
+
+                    if (itomChildFigure->getComplexStyle() != d->m_pData->m_cmplxType)
+                    {
+                        itomChildFigure->setComplexStyle(d->m_pData->m_cmplxType);
+                    }
                 }
 
                 QList<ito::AbstractNode::ParamNamePair> excludes;

--- a/itom2DQwtPlot/itom2dqwtplot.h
+++ b/itom2DQwtPlot/itom2dqwtplot.h
@@ -221,7 +221,7 @@ public:
 	ItomQwtPlotEnums::ScaleEngine getValueScale() const;
 	void setValueScale(const ItomQwtPlotEnums::ScaleEngine &scale);
 
-    void setPlaneRange(int min, int max);
+    void setPlaneRange(int min, int max, bool stackAndVolumeCutAllowed = true);
 
     virtual ito::AutoInterval getXAxisInterval(void) const;
     virtual void setXAxisInterval(ito::AutoInterval interval);

--- a/itom2DQwtPlot/plotCanvas.cpp
+++ b/itom2DQwtPlot/plotCanvas.cpp
@@ -1,7 +1,7 @@
 /* ********************************************************************
    itom measurement system
    URL: http://www.uni-stuttgart.de/ito
-   Copyright (C) 2020, Institut für Technische Optik (ITO),
+   Copyright (C) 2025, Institut für Technische Optik (ITO),
    Universität Stuttgart, Germany
 
    This file is part of itom.
@@ -898,26 +898,38 @@ ito::RetVal PlotCanvas::cutVolume(const ito::DataObject* dataObj, const QVector<
     if (bounds.size() == 2)
     {
         std::string description, unit;
-        int d = dataObj->getDims();
+        int dims = dataObj->getDims();
         unsigned int offsetByte;
-        //QVector<int> startPx(3); //convention x,y,z
         QVector<int> stepByte; //step to be done to next elem
+
+        // iterIdx is the axis index in the original dataObj that is used for the
+        // y-axis of the volume cut object. iterIdx is the first index of the first
+        // n-2 dimensions, whose size is > 1. If not possible, it is 0.
+        int iterIdx = 0;
+
+        for (int i = 0; i < dims - 2; ++i)
+        {
+            if (dataObj->getSize(i) > 1)
+            {
+                iterIdx = i;
+                break;
+            }
+        }
 
         int pxX1, pxX2, pxY1, pxY2, xSize, ySize;
         double yScaling, xScaling, yOffset, xOffset;
         bool _unused;
-        cv::Mat *mat;
-        pxX1 = qRound(dataObj->getPhysToPix(d - 1, bounds[0].x(), _unused));
-        pxY1 = qRound(dataObj->getPhysToPix(d - 2, bounds[0].y(), _unused));
-        pxX2 = qRound(dataObj->getPhysToPix(d - 1, bounds[1].x(), _unused));
-        pxY2 = qRound(dataObj->getPhysToPix(d - 2, bounds[1].y(), _unused));
+        pxX1 = qRound(dataObj->getPhysToPix(dims - 1, bounds[0].x(), _unused));
+        pxY1 = qRound(dataObj->getPhysToPix(dims - 2, bounds[0].y(), _unused));
+        pxX2 = qRound(dataObj->getPhysToPix(dims - 1, bounds[1].x(), _unused));
+        pxY2 = qRound(dataObj->getPhysToPix(dims - 2, bounds[1].y(), _unused));
 
-        saturation(pxX1, 0, dataObj->getSize(d - 1) - 1);
-        saturation(pxX2, 0, dataObj->getSize(d - 1) - 1);
-        saturation(pxY1, 0, dataObj->getSize(d - 2) - 1);
-        saturation(pxY2, 0, dataObj->getSize(d - 2) - 1);
+        saturation(pxX1, 0, dataObj->getSize(dims - 1) - 1);
+        saturation(pxX2, 0, dataObj->getSize(dims - 1) - 1);
+        saturation(pxY1, 0, dataObj->getSize(dims - 2) - 1);
+        saturation(pxY2, 0, dataObj->getSize(dims - 2) - 1);
 
-        mat = (cv::Mat*)dataObj->get_mdata()[dataObj->seekMat(0)]; //first plane in ROI
+        const cv::Mat* mat = dataObj->getCvPlaneMat(dataObj->seekMat(0)); //first plane in ROI
 
         if (pxX2 == pxX1)
         {
@@ -925,11 +937,12 @@ ito::RetVal PlotCanvas::cutVolume(const ito::DataObject* dataObj, const QVector<
             m_dir = dirY;
             stepByte.resize(1);
 
-            yScaling = d > 2 ? dataObj->getAxisScale(d - 3) : 1.0; // scaling along z of the host object
-            xScaling = d > 2 ? dataObj->getAxisScale(d - 2) : 1.0; // scaling along y of the host object
-            yOffset = d > 2 ? dataObj->getAxisOffset(d - 3) : 0.0;
-            xOffset = d > 2 ? dataObj->getAxisOffset(d - 2) : 0.0;
-            ySize = d > 2 ? dataObj->getSize(d - 3) : 0;
+            yScaling = dims > 2 ? dataObj->getAxisScale(iterIdx) : 1.0; // scaling along z of the host object
+            xScaling = dims > 2 ? dataObj->getAxisScale(dims - 2) : 1.0; // scaling along y of the host object
+            yOffset = dims > 2 ? dataObj->getAxisOffset(iterIdx) : 0.0;
+            xOffset = dims > 2 ? dataObj->getAxisOffset(dims - 2) : 0.0;
+            ySize = dims > 2 ? dataObj->getSize(iterIdx) : 0;
+
             if (pxY2 >= pxY1)
             {
                 xSize = 1 + pxY2 - pxY1;
@@ -945,7 +958,7 @@ ito::RetVal PlotCanvas::cutVolume(const ito::DataObject* dataObj, const QVector<
             {
                 stepByte[0] = dataObj->get_mdata()[0]->step[0];
             }
-            else// go in negative direction
+            else // go in negative direction
             {
                 stepByte[0] = -static_cast<int>(dataObj->get_mdata()[0]->step[0]);
             }
@@ -986,10 +999,10 @@ ito::RetVal PlotCanvas::cutVolume(const ito::DataObject* dataObj, const QVector<
                 break;
             default:
                 retval += ito::RetVal(ito::retError, 0, tr("type not implemented yet").toLatin1().data());
-
             }
-            description = dataObj->getAxisDescription(d - 2, _unused);
-            unit = dataObj->getAxisUnit(d - 2, _unused);
+
+            description = dataObj->getAxisDescription(dims - 2, _unused);
+            unit = dataObj->getAxisUnit(dims - 2, _unused);
 
             if (description == "")
             {
@@ -999,12 +1012,19 @@ ito::RetVal PlotCanvas::cutVolume(const ito::DataObject* dataObj, const QVector<
             m_dObjVolumeCut.setAxisDescription(1, description);
             m_dObjVolumeCut.setAxisUnit(1, unit);
 
-            description = dataObj->getAxisDescription(d - 3, _unused);
-            unit = dataObj->getAxisUnit(d - 3, _unused);
+            description = dataObj->getAxisDescription(iterIdx, _unused);
+            unit = dataObj->getAxisUnit(iterIdx, _unused);
 
             if (description == "")
             {
-                description = QObject::tr("z-axis").toLatin1().data();
+                if (iterIdx == dims - 3)
+                {
+                    description = QObject::tr("z-axis").toLatin1().data();
+                }
+                else
+                {
+                    description = QObject::tr("axis %1").arg(iterIdx).toLatin1().data();
+                }
             }
 
             m_dObjVolumeCut.setAxisDescription(0, description);
@@ -1012,11 +1032,11 @@ ito::RetVal PlotCanvas::cutVolume(const ito::DataObject* dataObj, const QVector<
             m_dObjVolumeCut.setValueUnit(dataObj->getValueUnit());
             m_dObjVolumeCut.setValueDescription(dataObj->getValueDescription());
 
-            m_dObjVolumeCut.setAxisOffset(0, dataObj->getAxisOffset(d - 3));
-            m_dObjVolumeCut.setAxisScale(0, dataObj->getAxisScale(d - 3));
+            m_dObjVolumeCut.setAxisOffset(0, dataObj->getAxisOffset(dims - 3));
+            m_dObjVolumeCut.setAxisScale(0, dataObj->getAxisScale(dims - 3));
 
-            double startPhys = dataObj->getPixToPhys(d - 2, pxY1, _unused);
-            double right = dataObj->getPixToPhys(d - 2, pxY2, _unused);
+            double startPhys = dataObj->getPixToPhys(dims - 2, pxY1, _unused);
+            double right = dataObj->getPixToPhys(dims - 2, pxY2, _unused);
             double scale = xSize > 1 ? (right - startPhys) / (float)(xSize - 1) : 0.0;
 
             m_dObjVolumeCut.setAxisScale(1, scale);
@@ -1026,11 +1046,11 @@ ito::RetVal PlotCanvas::cutVolume(const ito::DataObject* dataObj, const QVector<
         {
             m_dir = dirX;
             stepByte.resize(1);
-            yScaling = d > 2 ? dataObj->getAxisScale(d - 3) : 1.0; // scaling along z of the host object
-            xScaling = d > 2 ? dataObj->getAxisScale(d - 1) : 1.0; // scaling along y of the host object
-            yOffset = d > 2 ? dataObj->getAxisOffset(d - 3) : 0.0;
-            xOffset = d > 2 ? dataObj->getAxisOffset(d - 1) : 0.0;
-            ySize = d > 2 ? dataObj->getSize(d - 3) : 0;
+            yScaling = dims > 2 ? dataObj->getAxisScale(iterIdx) : 1.0; // scaling along z of the host object
+            xScaling = dims > 2 ? dataObj->getAxisScale(dims - 1) : 1.0; // scaling along y of the host object
+            yOffset = dims > 2 ? dataObj->getAxisOffset(iterIdx) : 0.0;
+            xOffset = dims > 2 ? dataObj->getAxisOffset(dims - 1) : 0.0;
+            ySize = dims > 2 ? dataObj->getSize(iterIdx) : 0;
 
             if (pxX2 >= pxX1)
             {
@@ -1091,8 +1111,8 @@ ito::RetVal PlotCanvas::cutVolume(const ito::DataObject* dataObj, const QVector<
                 retval += ito::RetVal(ito::retError, 0, tr("type not implemented yet").toLatin1().data());
             }
 
-            description = dataObj->getAxisDescription(d - 1, _unused);
-            unit = dataObj->getAxisUnit(d - 1, _unused);
+            description = dataObj->getAxisDescription(dims - 1, _unused);
+            unit = dataObj->getAxisUnit(dims - 1, _unused);
 
             if (description == "")
             {
@@ -1102,12 +1122,19 @@ ito::RetVal PlotCanvas::cutVolume(const ito::DataObject* dataObj, const QVector<
             m_dObjVolumeCut.setAxisDescription(1, description);
             m_dObjVolumeCut.setAxisUnit(1, unit);
 
-            description = dataObj->getAxisDescription(d - 3, _unused);
-            unit = dataObj->getAxisUnit(d - 3, _unused);
+            description = dataObj->getAxisDescription(iterIdx, _unused);
+            unit = dataObj->getAxisUnit(iterIdx, _unused);
 
             if (description == "")
             {
-                description = QObject::tr("z-axis").toLatin1().data();
+                if (iterIdx == dims - 3)
+                {
+                    description = QObject::tr("z-axis").toLatin1().data();
+                }
+                else
+                {
+                    description = QObject::tr("axis %1").arg(iterIdx).toLatin1().data();
+                }
             }
 
             m_dObjVolumeCut.setAxisDescription(0, description);
@@ -1115,11 +1142,11 @@ ito::RetVal PlotCanvas::cutVolume(const ito::DataObject* dataObj, const QVector<
             m_dObjVolumeCut.setValueUnit(dataObj->getValueUnit());
             m_dObjVolumeCut.setValueDescription(dataObj->getValueDescription());
 
-            m_dObjVolumeCut.setAxisOffset(0, dataObj->getAxisOffset(d - 3));
-            m_dObjVolumeCut.setAxisScale(0, dataObj->getAxisScale(d - 3));
+            m_dObjVolumeCut.setAxisOffset(0, dataObj->getAxisOffset(iterIdx));
+            m_dObjVolumeCut.setAxisScale(0, dataObj->getAxisScale(iterIdx));
 
-            double startPhys = dataObj->getPixToPhys(d - 1, pxX1, _unused);
-            double right = dataObj->getPixToPhys(d - 1, pxX2, _unused);
+            double startPhys = dataObj->getPixToPhys(dims - 1, pxX1, _unused);
+            double right = dataObj->getPixToPhys(dims - 1, pxX2, _unused);
             double scale = xSize > 1 ? (right - startPhys) / (float)(xSize - 1) : 0.0;
             m_dObjVolumeCut.setAxisScale(1, xSize > 1 ? (right - startPhys) / (float)(xSize - 1) : 0.0);
             m_dObjVolumeCut.setAxisOffset(1, -startPhys/scale);
@@ -1127,21 +1154,22 @@ ito::RetVal PlotCanvas::cutVolume(const ito::DataObject* dataObj, const QVector<
         else
         {
             m_dir=dirXY;
-            int dx = abs( pxX2 - pxX1 );
+            int dx = abs(pxX2 - pxX1);
             int incx = pxX1 <= pxX2 ? 1 : -1;
-            int dy = abs( pxY2 - pxY1 );
+            int dy = abs(pxY2 - pxY1);
             int incy = pxY1 <= pxY2 ? 1 : -1;
 
             xSize = 1 + std::max(dx,dy);
 
             //m_d.startPhys= 0.0;  //there is no physical starting point for diagonal lines.
-            yScaling = d > 2 ? dataObj->getAxisScale(d - 3) : 1.0;
-            yOffset = d > 2 ? dataObj->getAxisOffset(d - 3) : 0.0;
-            ySize = d > 2 ? dataObj->getSize(d - 3) : 0;
+            yScaling = dims > 2 ? dataObj->getAxisScale(iterIdx) : 1.0;
+            yOffset = dims > 2 ? dataObj->getAxisOffset(iterIdx) : 0.0;
+            ySize = dims > 2 ? dataObj->getSize(iterIdx) : 0;
+
             if (xSize > 0)
             {
-                double dxPhys = dataObj->getPixToPhys(d-1, pxX2, _unused) - dataObj->getPixToPhys(d-1, pxX1, _unused);
-                double dyPhys = dataObj->getPixToPhys(d-2, pxY2, _unused) - dataObj->getPixToPhys(d-2, pxY1, _unused);
+                double dxPhys = dataObj->getPixToPhys(dims - 1, pxX2, _unused) - dataObj->getPixToPhys(dims-1, pxX1, _unused);
+                double dyPhys = dataObj->getPixToPhys(dims - 2, pxY2, _unused) - dataObj->getPixToPhys(dims-2, pxY1, _unused);
                 xScaling = sqrt((dxPhys * dxPhys) + (dyPhys * dyPhys)) / (xSize - 1);
             }
             else
@@ -1181,8 +1209,8 @@ ito::RetVal PlotCanvas::cutVolume(const ito::DataObject* dataObj, const QVector<
             {  /* loop */
                 //setPixel(x,y)
                 stepByte[n] = (int)mat->step[0] * y + (int)mat->step[1] * x;
-
                 err -= es;
+
                 if (err < 0)
                 {
                     err += el;
@@ -1234,13 +1262,13 @@ ito::RetVal PlotCanvas::cutVolume(const ito::DataObject* dataObj, const QVector<
                 retval += ito::RetVal(ito::retError, 0, tr("type not implemented yet").toLatin1().data());
             }
 
-            description = dataObj->getAxisDescription(d - 2, _unused);
-            unit = dataObj->getAxisUnit(d - 2, _unused);
+            description = dataObj->getAxisDescription(dims - 2, _unused);
+            unit = dataObj->getAxisUnit(dims - 2, _unused);
 
             if (unit == "") unit = "px";
 
-            std::string descr2 = dataObj->getAxisDescription(d - 1, _unused);
-            std::string unit2 = dataObj->getAxisUnit(d - 1, _unused);
+            std::string descr2 = dataObj->getAxisDescription(dims - 1, _unused);
+            std::string unit2 = dataObj->getAxisUnit(dims - 1, _unused);
 
             if (unit2 == "") unit2 = "px";
 
@@ -1255,12 +1283,19 @@ ito::RetVal PlotCanvas::cutVolume(const ito::DataObject* dataObj, const QVector<
                 m_dObjVolumeCut.setAxisUnit(1, QString("%1/%2").arg(QString::fromLatin1(unit.data()), QString::fromLatin1(unit2.data())).toLatin1().data());
             }
 
-            description = dataObj->getAxisDescription(d - 3, _unused);
-            unit = dataObj->getAxisUnit(d - 3, _unused);
+            description = dataObj->getAxisDescription(iterIdx, _unused);
+            unit = dataObj->getAxisUnit(iterIdx, _unused);
 
             if (description == "")
             {
-                description = QObject::tr("z-axis").toLatin1().data();
+                if (iterIdx == dims - 3)
+                {
+                    description = QObject::tr("z-axis").toLatin1().data();
+                }
+                else
+                {
+                    description = QObject::tr("axis %1").arg(iterIdx).toLatin1().data();
+                }
             }
 
             m_dObjVolumeCut.setAxisDescription(0, description);
@@ -1268,8 +1303,8 @@ ito::RetVal PlotCanvas::cutVolume(const ito::DataObject* dataObj, const QVector<
             m_dObjVolumeCut.setValueUnit(dataObj->getValueUnit());
             m_dObjVolumeCut.setValueDescription(dataObj->getValueDescription());
             m_dObjVolumeCut.setAxisScale(1, xScaling);
-            m_dObjVolumeCut.setAxisOffset(0, dataObj->getAxisOffset(d - 3));
-            m_dObjVolumeCut.setAxisScale(0, dataObj->getAxisScale(d - 3));
+            m_dObjVolumeCut.setAxisOffset(0, dataObj->getAxisOffset(iterIdx));
+            m_dObjVolumeCut.setAxisScale(0, dataObj->getAxisScale(iterIdx));
         }
     }
 
@@ -1279,14 +1314,19 @@ ito::RetVal PlotCanvas::cutVolume(const ito::DataObject* dataObj, const QVector<
 void PlotCanvas::refreshPlot(const ito::DataObject *dObj,int plane /*= -1*/, const QVector<QPointF> bounds /*=QVector<QPointF>()*/ )
 {
     ito::RetVal retval;
+
     if (m_isRefreshingPlot || !m_pData)
     {
         return;
     }
 
+    int dims = 0;
+
     // the 2d plot does not accept a datetime or timedelta object
     if (dObj)
     {
+        dims = dObj->getDims();
+
         switch (dObj->getType())
         {
         case ito::tDateTime:
@@ -1313,6 +1353,7 @@ void PlotCanvas::refreshPlot(const ito::DataObject *dObj,int plane /*= -1*/, con
             {
                 dObj = &m_dObjVolumeCut;
                 m_dObjPtr = &m_dObjVolumeCut;
+                dims = dObj->getDims();
             }
         }
         else
@@ -1320,7 +1361,6 @@ void PlotCanvas::refreshPlot(const ito::DataObject *dObj,int plane /*= -1*/, con
             emit statusBarMessage(QObject::tr(retval.errorMessage()).toLatin1().data(), 10000);
         }
 
-        int dims = dObj->getDims();
         int width = dims > 0 ? dObj->getSize(dims - 1) : 0;
         int height = dims > 1 ? dObj->getSize(dims - 2) : 1;
 
@@ -1440,6 +1480,7 @@ void PlotCanvas::refreshPlot(const ito::DataObject *dObj,int plane /*= -1*/, con
     if (updateState != changeNo)
     {
         Itom2dQwtPlot *p = (Itom2dQwtPlot*)(this->parent());
+
         if (p)
         {
             int type = dObj->getType();
@@ -1470,9 +1511,21 @@ void PlotCanvas::refreshPlot(const ito::DataObject *dObj,int plane /*= -1*/, con
                 m_currentDataType = type;
             }
 
-            if (dObj->getDims() > 2)
+            if (dims)
             {
-                p->setPlaneRange(0, dObj->calcNumMats() - 1);
+                int numFirstDimsGreaterThan1 = 0;
+
+                for (int i = 0; i < dims - 2; ++i)
+                {
+                    // a zCut and volumeCut is only possible if only one
+                    // dimension of the first dims-2 dimensions has a size != 1.
+                    if (dObj->getSize(i) > 1)
+                    {
+                        numFirstDimsGreaterThan1++;
+                    }
+                }
+
+                p->setPlaneRange(0, dObj->calcNumMats() - 1, numFirstDimsGreaterThan1 <= 1);
             }
             else
             {


### PR DESCRIPTION
fix for zCut and volumeCut feature of 2d plot (itom2DQwtPlot): A zCut and volumeCut is only possible, if (a) the dataObject has more than two dimensions and (b) only ONE dimension among the first n-2 dimensions has a size > 1. Then the cuts are calculated along this axis with a size > 1. If more than one of the first axis has a size > 1, there is no "explainable" representation, therefore we disable the zCut and volumeCut features for these cases.

This fixes the issue https://github.com/itom-project/itom/issues/299 of the itom repository.

The detailed rules are:
**Case 1**: 
The dataObject has two dimensions: line cut displays a line through this plane, z-cut and volume cut are disabled

**Case 2**:
If the dataObject has > 2 dimensions and only one dimension in the first n-2 dimensions is != 1: Use this single dimension to represent the "z-direction" of the image stack

**Case 3**:
If the dataObject has > 2 dimensions and more than one dimension in the first n-2 dimensions has a size of != 1:  In this case, no z-cut and volume cut is possible. It will be disabled.